### PR TITLE
minimal: Split open and load in minimal.c as it creates issue in old Kernel version

### DIFF
--- a/src/minimal.c
+++ b/src/minimal.c
@@ -35,11 +35,19 @@ int main(int argc, char **argv)
 	/* Bump RLIMIT_MEMLOCK to allow BPF sub-system to do anything */
 	bump_memlock_rlimit();
 
-	/* Load and verify BPF application */
-	skel = minimal_bpf__open_and_load();
+/* Load and verify BPF application */
+	skel = minimal_bpf__open();
 	if (!skel) {
 		fprintf(stderr, "Failed to open and load BPF skeleton\n");
 		return 1;
+	}
+
+
+	/* Load & verify BPF programs */
+	err = minimal_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+		goto cleanup;
 	}
 
 	/* ensure BPF program only handles write() syscalls from our process */

--- a/src/minimal.c
+++ b/src/minimal.c
@@ -35,13 +35,15 @@ int main(int argc, char **argv)
 	/* Bump RLIMIT_MEMLOCK to allow BPF sub-system to do anything */
 	bump_memlock_rlimit();
 
-/* Load and verify BPF application */
+	/* Open BPF application */
 	skel = minimal_bpf__open();
 	if (!skel) {
-		fprintf(stderr, "Failed to open and load BPF skeleton\n");
+		fprintf(stderr, "Failed to open BPF skeleton\n");
 		return 1;
 	}
 
+	/* ensure BPF program only handles write() syscalls from our process */
+	skel->bss->my_pid = getpid();
 
 	/* Load & verify BPF programs */
 	err = minimal_bpf__load(skel);
@@ -49,9 +51,6 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
 		goto cleanup;
 	}
-
-	/* ensure BPF program only handles write() syscalls from our process */
-	skel->bss->my_pid = getpid();
 
 	/* Attach tracepoint handler */
 	err = minimal_bpf__attach(skel);


### PR DESCRIPTION
Update global variables from user-space after skeleton was loaded creates issue in old version of Kernel. Hence split the __open_and_load() into separate __open() and __load() to introduce initialization before __load()