### PR TITLE
makefile: use Linux UAPI headers distributed with libbpf

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,10 @@ LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= $(abspath ../tools/bpftool)
 LIBBPF_SRC := $(abspath ../libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
-INCLUDES := -I$(OUTPUT)
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi
 CFLAGS := -g -Wall
 ARCH := $(shell uname -m | sed 's/x86_64/x86/')
 


### PR DESCRIPTION
Avoid dependency on up-to-date Linux UAPI headers (mainly linux/bpf.h and
linux/btf.h) by using headers distributed with libbpf for its own compilation
needs.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>