### PR TITLE
Update gen_vmlinux_h.sh

### DIFF
--- a/tools/gen_vmlinux_h.sh
+++ b/tools/gen_vmlinux_h.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 
-$(dirname "$0")/bpftool btf dump file ${1:=/sys/kernel/btf/vmlinux} format c
+$(dirname "$0")/bpftool btf dump file ${1:-/sys/kernel/btf/vmlinux} format c


### PR DESCRIPTION
Positional or special parameters cannot be assigned using `:=` way. Should be `:-`.