### PR TITLE
fentry, kprobe: use process ID instead of thread ID

### DIFF
--- a/examples/c/fentry.bpf.c
+++ b/examples/c/fentry.bpf.c
@@ -9,12 +9,10 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 SEC("fentry/do_unlinkat")
 int BPF_PROG(do_unlinkat, int dfd, struct filename *name)
 {
-	const char *filename = name->name;
 	pid_t pid;
 
-	pid = bpf_get_current_pid_tgid();
-
-	bpf_printk("fentry: pid = %d, filename = %s\n", pid, filename);
+	pid = bpf_get_current_pid_tgid() >> 32;
+	bpf_printk("fentry: pid = %d, filename = %s\n", pid, name->name);
 	return 0;
 }
 
@@ -23,9 +21,7 @@ int BPF_PROG(do_unlinkat_exit, int dfd, struct filename *name, long ret)
 {
 	pid_t pid;
 
-	pid = bpf_get_current_pid_tgid();
-
+	pid = bpf_get_current_pid_tgid() >> 32;
 	bpf_printk("fexit: pid = %d, filename = %s, ret = %ld\n", pid, name->name, ret);
 	return 0;
 }
-

--- a/examples/c/kprobe.bpf.c
+++ b/examples/c/kprobe.bpf.c
@@ -10,18 +10,21 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 SEC("kprobe/do_unlinkat")
 int BPF_KPROBE(do_unlinkat, int dfd, struct filename *name)
 {
-	const char *filename = BPF_CORE_READ(name, name);
 	pid_t pid;
+	const char *filename;
 
-	pid = bpf_get_current_pid_tgid();
-
+	pid = bpf_get_current_pid_tgid() >> 32;
+	filename = BPF_CORE_READ(name, name);
 	bpf_printk("KPROBE ENTRY pid = %d, filename = %s\n", pid, filename);
 	return 0;
 }
 
 SEC("kretprobe/do_unlinkat")
-int BPF_KRETPROBE(do_open_execat_exit, long ret)
+int BPF_KRETPROBE(do_unlinkat_exit, long ret)
 {
-	bpf_printk("KPROBE EXIT: ret = %ld\n", ret);
+	pid_t pid;
+
+	pid = bpf_get_current_pid_tgid() >> 32;
+	bpf_printk("KPROBE EXIT: pid = %d, ret = %ld\n", pid, ret);
 	return 0;
 }


### PR DESCRIPTION
Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>