### PR TITLE
add xmake.lua to build bpf c examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /build
+/examples/c/build
+/examples/c/.xmake

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ $ sudo ./bootstrap
 XMake build (Linux):
 
 ```shell
+$ git submodule update --init --recursive       # check out libbpf
 $ cd examples/c
 $ xmake
 $ xmake run bootstrap
@@ -229,6 +230,7 @@ $ xmake run bootstrap
 XMake build (Android):
 
 ```shell
+$ git submodule update --init --recursive       # check out libbpf
 $ cd examples/c
 $ xmake f -p android
 $ xmake

--- a/README.md
+++ b/README.md
@@ -218,6 +218,29 @@ $ sudo ./bootstrap
 <...>
 ```
 
+XMake build (Linux):
+
+```shell
+$ cd examples/c
+$ xmake
+$ xmake run bootstrap
+```
+
+XMake build (Android):
+
+```shell
+$ cd examples/c
+$ xmake f -p android
+$ xmake
+```
+
+Install [Xmake](https://github.com/xmake-io/xmake)
+
+```shell
+$ bash <(wget https://xmake.io/shget.text -O -)
+$ source ~/.xmake/profile
+```
+
 ## Rust Examples
 
 Install `libbpf-cargo`:

--- a/examples/c/xmake.lua
+++ b/examples/c/xmake.lua
@@ -6,9 +6,6 @@ option("system-libbpf",      {showmenu = true, default = false, description = "U
 option("require-bpftool",    {showmenu = true, default = false, description = "Require bpftool package"})
 
 add_requires("libelf", "zlib")
-if has_config("require-bpftool") then
-    add_requires("linux-tools", {configs = {bpftool = true}})
-end
 if is_plat("android") then
     add_requires("ndk >=22.x", "argp-standalone")
     set_toolchains("@ndk", {sdkver = "23"})
@@ -22,6 +19,7 @@ add_includedirs("../../vmlinux")
 
 -- we can run `xmake f --require-bpftool=y` to pull bpftool from xmake-repo repository
 if has_config("require-bpftool") then
+    add_requires("linux-tools", {configs = {bpftool = true}})
     add_packages("linux-tools")
 else
     before_build(function (target)

--- a/examples/c/xmake.lua
+++ b/examples/c/xmake.lua
@@ -3,7 +3,7 @@ add_rules("platform.linux.bpf")
 set_license("GPL-2.0")
 
 add_requires("linux-tools", {configs = {bpftool = true}})
-add_requires("libbpf")
+add_requires("libbpf", {system = false})
 if is_plat("android") then
     add_requires("ndk >=22.x", "argp-standalone")
     set_toolchains("@ndk", {sdkver = "23"})

--- a/examples/c/xmake.lua
+++ b/examples/c/xmake.lua
@@ -1,0 +1,40 @@
+add_rules("mode.release", "mode.debug")
+add_rules("platform.linux.bpf")
+set_license("GPL-2.0")
+
+add_requires("linux-tools", {configs = {bpftool = true}})
+add_requires("libbpf")
+if is_plat("android") then
+    add_requires("ndk >=22.x", "argp-standalone")
+    set_toolchains("@ndk", {sdkver = "23"})
+else
+    add_requires("llvm >=10.x")
+    set_toolchains("@llvm")
+    add_requires("linux-headers")
+end
+
+add_includedirs("../../vmlinux")
+add_packages("linux-tools", "linux-headers", "libbpf")
+
+target("minimal")
+    set_kind("binary")
+    add_files("minimal*.c")
+
+target("bootstrap")
+    set_kind("binary")
+    add_files("bootstrap*.c")
+    if is_plat("android") then
+        add_packages("argp-standalone")
+    end
+
+target("fentry")
+    set_kind("binary")
+    add_files("fentry*.c")
+
+target("kprobe")
+    set_kind("binary")
+    add_files("kprobe*.c")
+    if is_plat("android") then
+        -- TODO we need fix vmlinux.h tu support android
+        set_default(false)
+    end

--- a/examples/c/xmake.lua
+++ b/examples/c/xmake.lua
@@ -2,8 +2,8 @@ add_rules("mode.release", "mode.debug")
 add_rules("platform.linux.bpf")
 set_license("GPL-2.0")
 
+add_requires("libelf", "zlib")
 add_requires("linux-tools", {configs = {bpftool = true}})
-add_requires("libbpf", {system = false})
 if is_plat("android") then
     add_requires("ndk >=22.x", "argp-standalone")
     set_toolchains("@ndk", {sdkver = "23"})
@@ -14,26 +14,46 @@ else
 end
 
 add_includedirs("../../vmlinux")
-add_packages("linux-tools", "linux-headers", "libbpf")
+
+target("libbpf")
+    set_kind("static")
+    set_basename("bpf")
+    add_files("../../libbpf/src/*.c")
+    add_includedirs("../../libbpf/include")
+    add_includedirs("../../libbpf/include/uapi", {public = true})
+    add_includedirs("$(buildir)", {interface = true})
+    add_configfiles("../../libbpf/src/(*.h)", {prefixdir = "bpf"})
+    add_packages("libelf", "zlib")
+    if is_plat("android") then
+        add_defines("__user=", "__force=", "__poll_t=uint32_t")
+    end
 
 target("minimal")
     set_kind("binary")
+    add_deps("libbpf")
     add_files("minimal*.c")
+    add_packages("linux-tools", "linux-headers")
 
 target("bootstrap")
     set_kind("binary")
+    add_deps("libbpf")
     add_files("bootstrap*.c")
+    add_packages("linux-tools", "linux-headers")
     if is_plat("android") then
         add_packages("argp-standalone")
     end
 
 target("fentry")
     set_kind("binary")
+    add_deps("libbpf")
     add_files("fentry*.c")
+    add_packages("linux-tools", "linux-headers")
 
 target("kprobe")
     set_kind("binary")
+    add_deps("libbpf")
     add_files("kprobe*.c")
+    add_packages("linux-tools", "linux-headers")
     if is_plat("android") then
         -- TODO we need fix vmlinux.h tu support android
         set_default(false)

--- a/examples/c/xmake.lua
+++ b/examples/c/xmake.lua
@@ -2,8 +2,13 @@ add_rules("mode.release", "mode.debug")
 add_rules("platform.linux.bpf")
 set_license("GPL-2.0")
 
+option("system-libbpf",      {showmenu = true, default = false, description = "Use system-installed libbpf"})
+option("require-bpftool",    {showmenu = true, default = false, description = "Require bpftool package"})
+
 add_requires("libelf", "zlib")
-add_requires("linux-tools", {configs = {bpftool = true}})
+if has_config("require-bpftool") then
+    add_requires("linux-tools", {configs = {bpftool = true}})
+end
 if is_plat("android") then
     add_requires("ndk >=22.x", "argp-standalone")
     set_toolchains("@ndk", {sdkver = "23"})
@@ -15,45 +20,69 @@ end
 
 add_includedirs("../../vmlinux")
 
-target("libbpf")
-    set_kind("static")
-    set_basename("bpf")
-    add_files("../../libbpf/src/*.c")
-    add_includedirs("../../libbpf/include")
-    add_includedirs("../../libbpf/include/uapi", {public = true})
-    add_includedirs("$(buildir)", {interface = true})
-    add_configfiles("../../libbpf/src/(*.h)", {prefixdir = "bpf"})
-    add_packages("libelf", "zlib")
-    if is_plat("android") then
-        add_defines("__user=", "__force=", "__poll_t=uint32_t")
-    end
+-- we can run `xmake f --require-bpftool=y` to pull bpftool from xmake-repo repository
+if has_config("require-bpftool") then
+    add_packages("linux-tools")
+else
+    before_build(function (target)
+        os.addenv("PATH", path.join(os.scriptdir(), "..", "..", "tools"))
+    end)
+end
+
+-- we use the vendored libbpf sources for libbpf-bootstrap.
+-- for some projects you may want to use the system-installed libbpf, so you can run `xmake f --system-libbpf=y`
+if has_config("system-libbpf") then
+    add_requires("libbpf", {system = true})
+else
+    target("libbpf")
+        set_kind("static")
+        set_basename("bpf")
+        add_files("../../libbpf/src/*.c")
+        add_includedirs("../../libbpf/include")
+        add_includedirs("../../libbpf/include/uapi", {public = true})
+        add_includedirs("$(buildir)", {interface = true})
+        add_configfiles("../../libbpf/src/(*.h)", {prefixdir = "bpf"})
+        add_packages("libelf", "zlib")
+        if is_plat("android") then
+            add_defines("__user=", "__force=", "__poll_t=uint32_t")
+        end
+end
 
 target("minimal")
     set_kind("binary")
-    add_deps("libbpf")
     add_files("minimal*.c")
-    add_packages("linux-tools", "linux-headers")
+    add_packages("linux-headers")
+    if not has_config("system-libbpf") then
+        add_deps("libbpf")
+    end
 
 target("bootstrap")
     set_kind("binary")
-    add_deps("libbpf")
     add_files("bootstrap*.c")
-    add_packages("linux-tools", "linux-headers")
+    add_packages("linux-headers")
+    if not has_config("system-libbpf") then
+        add_deps("libbpf")
+    end
     if is_plat("android") then
         add_packages("argp-standalone")
     end
 
 target("fentry")
     set_kind("binary")
-    add_deps("libbpf")
     add_files("fentry*.c")
-    add_packages("linux-tools", "linux-headers")
+    add_packages("linux-headers")
+    if not has_config("system-libbpf") then
+        add_deps("libbpf")
+    end
+
 
 target("kprobe")
     set_kind("binary")
-    add_deps("libbpf")
     add_files("kprobe*.c")
-    add_packages("linux-tools", "linux-headers")
+    add_packages("linux-headers")
+    if not has_config("system-libbpf") then
+        add_deps("libbpf")
+    end
     if is_plat("android") then
         -- TODO we need fix vmlinux.h tu support android
         set_default(false)


### PR DESCRIPTION
Related issues: https://github.com/libbpf/libbpf-bootstrap/issues/17

I disable kprobe for android now, because it will compile fail if I use current vmlinux.h.

```console
$ xmake 
[ 20%]: compiling.bpf minimal.bpf.c
[ 20%]: compiling.bpf bootstrap.bpf.c
[ 20%]: compiling.bpf kprobe.bpf.c
[ 20%]: compiling.bpf fentry.bpf.c
error: kprobe.bpf.c:11:5: error: no member named 'uregs' in 'struct pt_regs'
int BPF_KPROBE(do_unlinkat, int dfd, struct filename *name)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ruki/.xmake/packages/l/libbpf/v0.3/3fdb468c64a048da9c2e51edfd3a7afc/include/bpf/bpf_tracing.h:385:20: note: expanded from macro 'BPF_KPROBE'
        return ____##name(___bpf_kprobe_args(args));                        \
                          ^~~~~~~~~~~~~~~~~~~~~~~~
/home/ruki/.xmake/packages/l/libbpf/v0.3/3fdb468c64a048da9c2e51edfd3a7afc/include/bpf/bpf_tracing.h:365:2: note: expanded from macro '___bpf_kprobe_args'
        ___bpf_apply(___bpf_kprobe_args, ___bpf_narg(args))(args)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ruki/.xmake/packages/l/libbpf/v0.3/3fdb468c64a048da9c2e51edfd3a7afc/include/bpf/bpf_tracing.h:299:29: note: expanded from macro '___bpf_apply'
#define ___bpf_apply(fn, n) ___bpf_concat(fn, n)
```
