### PR TITLE
examples/c: add output trace instructions to minimal and uprobe examples

### DIFF
--- a/examples/c/fentry.c
+++ b/examples/c/fentry.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe`"
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
 	       "to see output of the BPF programs.\n");
 
 	while (!stop) {

--- a/examples/c/kprobe.c
+++ b/examples/c/kprobe.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe`"
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
 	       "to see output of the BPF programs.\n");
 
 	while (!stop) {

--- a/examples/c/minimal.c
+++ b/examples/c/minimal.c
@@ -59,7 +59,8 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Successfully started!\n");
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
 
 	for (;;) {
 		/* trigger our BPF program */

--- a/examples/c/uprobe.c
+++ b/examples/c/uprobe.c
@@ -122,7 +122,8 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Successfully started!\n");
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
 
 	for (i = 0; ; i++) {
 		/* trigger our BPF programs */


### PR DESCRIPTION
Like in the fentry and kprobe examples, show the instructions of how to
get the trace output in the start message.

Also add a space after the command in all examples.