### PR TITLE
Add example for uprobes and kprobes

### DIFF
--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
+  "tracecon",
   "xdp",
 ]

--- a/examples/rust/tracecon/.gitignore
+++ b/examples/rust/tracecon/.gitignore
@@ -1,0 +1,3 @@
+src/bpf/.output
+src/bpf/vmlinux.h
+target

--- a/examples/rust/tracecon/Cargo.lock
+++ b/examples/rust/tracecon/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "memchr"
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9023c1c0973b327f073c7f2fceb9bcc049862f93a7d14c6feb46c8a56460a0d5"
+checksum = "4f26e9fafdc766a38d6929975130ddc0f3d4fda5c10a8ec7acf67fd01f13c1d1"
 dependencies = [
  "flate2",
  "memchr",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -502,18 +502,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,18 +609,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -664,9 +664,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vec_map"
@@ -723,15 +723,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "xdp"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "ctrlc",
- "libbpf-cargo",
- "libbpf-rs",
- "libc",
- "structopt",
-]

--- a/examples/rust/tracecon/Cargo.toml
+++ b/examples/rust/tracecon/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tracecon"
+version = "0.1.0"
+authors = ["Magnus Kulke <mkulke@gmail.com>"]
+edition = "2018"
+license = "GPL-2.0 OR BSD-3-Clause"
+
+[dependencies]
+anyhow = "1.0"
+libbpf-rs = "0.10"
+libc = "0.2"
+structopt = "0.3"
+ctrlc = "3.1"
+object = "0.25"
+plain = "0.2"
+
+[build-dependencies]
+libbpf-cargo = "0.7"

--- a/examples/rust/tracecon/README.md
+++ b/examples/rust/tracecon/README.md
@@ -1,0 +1,88 @@
+# tracecon
+
+An eBPF sample application, written in C & Rust using
+[libbpf-rs](https://github.com/libbpf/libbpf-rs). It will output all
+TCPv4 connections that have been established on the host as ips and
+hostnames by probing `tcp_v4_connect` in kernel and glibc's `getaddrinfo`
+in userland. On a successful host lookup the first result will be stored in
+a hashmap, which can be used as a lookup table to retrieve a hostname for
+ip_v4 connections.
+
+## Requirements
+
+### Kernel
+
+The project is built on technology like `CO-RE` and `BTF`, which is only
+available in more recent kernels (5.0-ish). Ubuntu 20.10 has configured and
+packaged all the required dependencies.
+
+### Compilers
+
+The project has been tested with LLVM v11 and Rust v1.52.1.
+
+### Generate `vmlinux.h`
+
+```bash
+bpftool btf dump file /sys/kernel/btf/vmlinux format c > src/bpf/vmlinux.h
+```
+
+You can verify whether your kernel was built with BTF enabled:
+
+```bash
+cat /boot/config-$(uname -a) | grep CONFIG_DEBUG_INFO_BTF
+```
+
+## Build
+
+### Vagrant
+
+eBPF is a low-level technology on the Linux kernel. Docker is not a good fit
+to build eBPF code on MacOS or Windows environments. On those platforms
+Docker ships its own kernel (e.g. linuxkit) and BTF might not be enabled.
+
+There is a `Vagrantfile` to provision a Ubuntu 20.10 VM including the
+necessary dependencies to build the project. To install Vagrant with a
+VirtualBox backend and provision the VM on a MacOS host machine run:
+
+```
+brew cask install virtualbox
+brew cask install vagrant
+vagrant up
+```
+
+Log in to the machine. The current host workdir is mounted to `/vagrant`:
+
+```
+vagrant ssh
+sudo su -
+cd /vagrant
+```
+
+### Cargo
+
+```bash
+cargo build
+```
+
+## Run
+
+Start the program to instrument the eBPF probe and listen to events:
+
+```bash
+cargo run --release
+```
+
+In another shell perform some http calls:
+
+```bash
+curl -s www.jsonplaceholder.com > /dev/null
+# Do not use a dns lookup
+curl -s -H "Host: www.jsonplaceholder.com" 172.67.201.157 > /dev/null
+```
+
+The other shell should show the respective events:
+
+```bash
+host event: www.jsonplaceholder.com
+ip event: 172.67.201.157
+```

--- a/examples/rust/tracecon/Vagrantfile
+++ b/examples/rust/tracecon/Vagrantfile
@@ -1,0 +1,82 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/groovy64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder ".", "/src", type: "rsync"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = false
+  
+    # Customize the amount of memory on the VM:
+    vb.memory = "16384"
+    vb.cpus = 4
+  end
+
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update -y
+    apt-get install -y \
+      build-essential \
+      curl \
+      libbpf-dev \
+      clang \
+      libelf-dev \
+      linux-tools-$(uname -r)
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    bpftool btf dump file \
+      /sys/kernel/btf/vmlinux \
+      format c > /vagrant/src/bpf/vmlinux.h
+  SHELL
+end

--- a/examples/rust/tracecon/build.rs
+++ b/examples/rust/tracecon/build.rs
@@ -1,0 +1,23 @@
+use std::fs::create_dir_all;
+use std::path::Path;
+
+use libbpf_cargo::SkeletonBuilder;
+
+const SRC: &str = "./src/bpf/tracecon.bpf.c";
+
+fn main() {
+    // It's unfortunate we cannot use `OUT_DIR` to store the generated skeleton.
+    // Reasons are because the generated skeleton contains compiler attributes
+    // that cannot be `include!()`ed via macro. And we cannot use the `#[path = "..."]`
+    // trick either because you cannot yet `concat!(env!("OUT_DIR"), "/skel.rs")` inside
+    // the path attribute either (see https://github.com/rust-lang/rust/pull/83366).
+    //
+    // However, there is hope! When the above feature stabilizes we can clean this
+    // all up.
+    create_dir_all("./src/bpf/.output").unwrap();
+    let skel = Path::new("./src/bpf/.output/tracecon.skel.rs");
+    SkeletonBuilder::new(SRC)
+        .generate(&skel)
+        .expect("bpf compilation failed");
+    println!("cargo:rerun-if-changed={}", SRC);
+}

--- a/examples/rust/tracecon/src/bpf/tracecon.bpf.c
+++ b/examples/rust/tracecon/src/bpf/tracecon.bpf.c
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#define memcpy(dest, src, n) __builtin_memcpy((dest), (src), (n))
+#define HOSTNAME_LEN 84
+
+const volatile pid_t target_pid = 0;
+
+/* Copied from: include/netdb.h */
+struct addrinfo {
+	int ai_flags; /* Input flags.  */
+	int ai_family; /* Protocol family for socket.  */
+	int ai_socktype; /* Socket type.  */
+	int ai_protocol; /* Protocol for socket.  */
+	u32 ai_addrlen; /* Length of socket address.  */
+	struct sockaddr *ai_addr; /* Socket address for socket.  */
+	char *ai_canonname; /* Canonical name for service location.  */
+	struct addrinfo *ai_next; /* Pointer to next in list.  */
+};
+
+struct lookup {
+	char c[84];
+	struct addrinfo **results;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, struct lookup);
+} lookups SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, struct lookup);
+} hostnames SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, struct sock *);
+} sockets SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+enum tag { IP = 0, HOSTNAME = 1 };
+
+struct event {
+	u8 tag;
+	u8 ip[4];
+	u8 hostname[HOSTNAME_LEN];
+};
+
+/* trigger creation of event struct in skeleton code */
+struct event _event = {};
+
+static u32 get_tid()
+{
+	u64 tgid = bpf_get_current_pid_tgid();
+	pid_t pid = tgid >> 32;
+
+	if (target_pid != 0 && target_pid != pid)
+		return 0;
+	return (u32)tgid;
+}
+
+SEC("uprobe/getaddrinfo")
+int BPF_KPROBE(getaddrinfo_enter, const char *hostname, const char *service,
+	       const struct addrinfo *hints, struct addrinfo **res)
+{
+	u32 tid = get_tid();
+	struct lookup lookup = {};
+
+	if (!tid)
+		return 0;
+	bpf_probe_read_user_str(&lookup.c, sizeof(lookup.c), hostname);
+	lookup.results = res;
+	bpf_map_update_elem(&lookups, &tid, &lookup, BPF_ANY);
+	return 0;
+}
+
+SEC("uretprobe/getaddrinfo")
+int BPF_KRETPROBE(getaddrinfo_exit, int ret)
+{
+	u32 tid = get_tid();
+	struct lookup *lookup;
+	struct addrinfo *result;
+	struct sockaddr_in *addr;
+	struct in_addr ipv4_addr;
+
+	if (!tid)
+		return 0;
+	if (ret != 0)
+		goto cleanup;
+	lookup = bpf_map_lookup_elem(&lookups, &tid);
+	if (!lookup)
+		return 0;
+	bpf_probe_read_user(&result, sizeof(result), lookup->results);
+	bpf_probe_read_user(&addr, sizeof(addr), &result->ai_addr);
+	bpf_probe_read_user(&ipv4_addr, sizeof(ipv4_addr), &addr->sin_addr);
+	bpf_map_update_elem(&hostnames, &ipv4_addr.s_addr, lookup, BPF_ANY);
+cleanup:
+	bpf_map_delete_elem(&lookups, &tid);
+	return 0;
+}
+
+
+SEC("kprobe/tcp_v4_connect")
+int BPF_KPROBE(tcp_v4_connect_enter, struct sock *sk, struct sockaddr *uaddr, int addr_len)
+{
+	u32 tid = get_tid();
+
+	if (!tid)
+		return 0;
+	bpf_map_update_elem(&sockets, &tid, &sk, 0);
+	return 0;
+};
+
+SEC("kretprobe/tcp_v4_connect")
+int BPF_KRETPROBE(tcp_v4_connect_exit, int ret)
+{
+	u32 tid = get_tid();
+	struct sock **sockpp;
+	struct lookup *lookup;
+	struct event event = {};
+	u32 ip;
+
+	if (!tid)
+		return 0;
+	if (ret != 0)
+		goto cleanup;
+	sockpp = bpf_map_lookup_elem(&sockets, &tid);
+	if (!sockpp)
+		return 0;
+	ip = BPF_CORE_READ(*sockpp, __sk_common.skc_daddr);
+	lookup = bpf_map_lookup_elem(&hostnames, &ip);
+	if (!lookup) {
+		event.tag = IP;
+		memcpy(&event.ip, &ip, sizeof(event.ip));
+	} else {
+		event.tag = HOSTNAME;
+		memcpy(&event.hostname, &lookup->c, sizeof(lookup->c));
+		bpf_map_delete_elem(&hostnames, &ip);
+	}
+	/* ctx is implied in the signature macro */
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+cleanup:
+	bpf_map_delete_elem(&sockets, &tid);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/examples/rust/tracecon/src/main.rs
+++ b/examples/rust/tracecon/src/main.rs
@@ -1,0 +1,127 @@
+use anyhow::{anyhow, bail, Result};
+use core::time::Duration;
+use libbpf_rs::PerfBufferBuilder;
+use object::Object;
+use object::ObjectSymbol;
+use plain::Plain;
+use std::fs;
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use structopt::StructOpt;
+
+#[path = "bpf/.output/tracecon.skel.rs"]
+mod tracecon;
+use tracecon::*;
+
+type Event = tracecon_bss_types::event;
+unsafe impl Plain for Event {}
+
+#[derive(Debug, StructOpt)]
+struct Command {
+    /// verbose output
+    #[structopt(long, short)]
+    verbose: bool,
+    /// glibc path
+    #[structopt(long, short, default_value = "/lib/x86_64-linux-gnu/libc.so.6")]
+    glibc: String,
+    #[structopt(long, short)]
+    /// pid to observe
+    pid: Option<i32>,
+}
+
+fn bump_memlock_rlimit() -> Result<()> {
+    let rlimit = libc::rlimit {
+        rlim_cur: 128 << 20,
+        rlim_max: 128 << 20,
+    };
+
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+        bail!("Failed to increase rlimit");
+    }
+
+    Ok(())
+}
+
+fn get_symbol_address(so_path: &str, fn_name: &str) -> Result<usize> {
+    let path = Path::new(so_path);
+    let buffer = fs::read(path)?;
+    let file = object::File::parse(buffer.as_slice())?;
+
+    let mut symbols = file.dynamic_symbols();
+    let symbol = symbols
+        .find(|symbol| {
+            if let Ok(name) = symbol.name() {
+                return name == fn_name;
+            }
+            false
+        })
+        .ok_or(anyhow!("symbol not found"))?;
+
+    Ok(symbol.address() as usize)
+}
+
+fn handle_event(_cpu: i32, data: &[u8]) {
+    let mut event = Event::default();
+    plain::copy_from_bytes(&mut event, data).expect("Event data buffer was too short");
+
+    match event.tag {
+        0 => println!("ip event: {}", Ipv4Addr::from(event.ip)),
+        1 => println!("host event: {}", String::from_utf8_lossy(&event.hostname)),
+        _ => {}
+    }
+}
+
+fn main() -> Result<()> {
+    let opts = Command::from_args();
+
+    let mut skel_builder = TraceconSkelBuilder::default();
+    if opts.verbose {
+        skel_builder.obj_builder.debug(true);
+    }
+
+    bump_memlock_rlimit()?;
+    let mut open_skel = skel_builder.open()?;
+    if let Some(pid) = opts.pid {
+        open_skel.rodata().target_pid = pid;
+    }
+    let mut skel = open_skel.load()?;
+    let address = get_symbol_address(&opts.glibc, "getaddrinfo")?;
+
+    let _uprobe =
+        skel.progs_mut()
+            .getaddrinfo_enter()
+            .attach_uprobe(false, -1, &opts.glibc, address)?;
+
+    let _uretprobe =
+        skel.progs_mut()
+            .getaddrinfo_exit()
+            .attach_uprobe(true, -1, &opts.glibc, address)?;
+
+    let _kprobe = skel
+        .progs_mut()
+        .tcp_v4_connect_enter()
+        .attach_kprobe(false, "tcp_v4_connect")?;
+
+    let _kretprobe = skel
+        .progs_mut()
+        .tcp_v4_connect_exit()
+        .attach_kprobe(true, "tcp_v4_connect")?;
+
+    let perf = PerfBufferBuilder::new(skel.maps_mut().events())
+        .sample_cb(handle_event)
+        .build()?;
+
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })?;
+
+    while running.load(Ordering::SeqCst) {
+        perf.poll(Duration::from_millis(100))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Added a sample application for libbpf-rs. It will output all TCPv4 connections that have been established on the host as ips and hostnames by probing `tcp_v4_connect` in kernel and glibc's `getaddrinfo` in userland. On a successful host lookup the first result will be stored in a hashmap, which can be used as a lookup table to retrieve a hostname for ip_v4 connections. When the program is started there should be console output when TCPv4 connections are established on the system, eg. via curl:

```bash   
host event: www.jsonplaceholder.com
ip event: 172.67.201.157
```