### PR TITLE
Remove Rust's redundant build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ $ cargo install libbpf-cargo
 Build using `cargo`:
 ```shell
 $ cd examples/rust
-$ cargo libbpf build
-$ cargo libbpf gen
 $ cargo build --release
 $ sudo ./target/release/xdp 1
 <...>


### PR DESCRIPTION
Since the example uses a build script, using the cargo plugin commands in the example is redundant.
Removing it would clarify the build process.