### PR TITLE
examples/c: convertion between different architectures

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -11,7 +11,7 @@ VMLINUX := ../../vmlinux/vmlinux.h
 # outdated
 INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
 CFLAGS := -g -Wall
-ARCH := $(shell uname -m | sed 's/x86_64/x86/')
+ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
 
 APPS = minimal bootstrap uprobe kprobe fentry
 


### PR DESCRIPTION
Currently `aarch64` is not present in the supported arch list `__TARGET_ARCH_xxx`: https://github.com/torvalds/linux/blob/master/tools/lib/bpf/bpf_tracing.h#L6-L29

To successfully compile the example/c programs, we need a conversion from `aarch64` to `arm64`.

---
UPDATE:
Align to the BCC makefile for more elegant conversion of differnet architectures:
https://github.com/iovisor/bcc/blob/master/libbpf-tools/Makefile#L12