### PR TITLE
examples/rust: provide file name context

### DIFF
--- a/examples/rust/tracecon/src/main.rs
+++ b/examples/rust/tracecon/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use core::time::Duration;
 use libbpf_rs::PerfBufferBuilder;
 use object::Object;
@@ -46,7 +46,8 @@ fn bump_memlock_rlimit() -> Result<()> {
 
 fn get_symbol_address(so_path: &str, fn_name: &str) -> Result<usize> {
     let path = Path::new(so_path);
-    let buffer = fs::read(path)?;
+    let buffer =
+        fs::read(path).with_context(|| format!("could not read file `{}`", path.display()))?;
     let file = object::File::parse(buffer.as_slice())?;
 
     let mut symbols = file.dynamic_symbols();


### PR DESCRIPTION
The tracecon example tries to read the glibc library
"/lib/x86_64-linux-gnu/libc.so.6", but normally in rpm
system it is located in "/lib64/libc.so.6".

With the current implementation you got the following error:
`Error: No such file or directory (os error 2)`

PR changes:
```
Error: could not read file `/lib/x86_64-linux-gnu/libc.so.6`

Caused by:
    No such file or directory (os error 2)
```
It provides some more context on which file was not able to open, then you can check the options and run it providing the correct glibc:
`cargo run -- --glibc /lib64/libc.so.6`