### PR TITLE
Add new minimal_legacy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
 `minimal` is great as a bare-bones experimental playground to quickly try out
 new ideas or BPF features.
 
+## Minimal_Legacy
+
+This version of `minimal` is modified to allow running on even older kernels
+that do not allow global variables. bpf_printk uses global variables unless
+BPF_NO_GLOBAL_DATA is defined before including bpf_helpers.h. Additionally,
+the global variable my_pid has been replaced with an array of one element to
+hold the process pid.
+
+```
+$ cd examples/c
+$ make minimal_legacy
+$ sudo ./minimal_legacy
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+  minimal_legacy-52030 [001] .... 491227.784078: 0x00000001: BPF triggered from PID 52030.
+  minimal_legacy-52030 [001] .... 491228.840571: 0x00000001: BPF triggered from PID 52030.
+  minimal_legacy-52030 [001] .... 491229.841643: 0x00000001: BPF triggered from PID 52030.
+  minimal_legacy-52030 [001] .... 491230.842432: 0x00000001: BPF triggered from PID 52030.
+```
+
 ## Bootstrap
 
 `bootstrap` is an example of a simple (but realistic) BPF application. It

--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -18,7 +18,7 @@ INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
 CFLAGS := -g -Wall
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
 
-APPS = minimal bootstrap uprobe kprobe fentry
+APPS = minimal minimal_legacy bootstrap uprobe kprobe fentry
 
 CARGO ?= $(shell which cargo)
 ifeq ($(strip $(CARGO)),)

--- a/examples/c/minimal_legacy.bpf.c
+++ b/examples/c/minimal_legacy.bpf.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#define BPF_NO_GLOBAL_DATA
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+typedef unsigned int u32;
+typedef int pid_t;
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+/* Create an array with 1 entry instead of a global variable
+ * which does not work with older kernels */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, pid_t);
+} my_pid_map SEC(".maps");
+
+SEC("tp/syscalls/sys_enter_write")
+int handle_tp(void *ctx)
+{
+	u32 index = 0;
+	pid_t pid = bpf_get_current_pid_tgid() >> 32;
+	pid_t *my_pid = bpf_map_lookup_elem(&my_pid_map, &index);
+
+	if (!my_pid || *my_pid != pid)
+		return 1;
+
+	bpf_printk("BPF triggered from PID %d.\n", pid);
+
+	return 0;
+}

--- a/examples/c/minimal_legacy.c
+++ b/examples/c/minimal_legacy.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include "minimal_legacy.skel.h"
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+int main(int argc, char **argv)
+{
+	struct minimal_legacy_bpf *skel;
+	int err;
+	pid_t pid;
+	unsigned index = 0;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Load and verify BPF application */
+	skel = minimal_legacy_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open and load BPF skeleton\n");
+		return 1;
+	}
+
+	/* ensure BPF program only handles write() syscalls from our process */
+	pid = getpid();
+	err = bpf_map__update_elem(skel->maps.my_pid_map, &index, sizeof(index), &pid, sizeof(pid_t), BPF_ANY);
+	if (err < 0) {
+		fprintf(stderr, "Error updating map with pid: %s\n", strerror(err));
+		goto cleanup;
+	}
+
+	/* Attach tracepoint handler */
+	err = minimal_legacy_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
+
+	for (;;) {
+		/* trigger our BPF program */
+		fprintf(stderr, ".");
+		sleep(1);
+	}
+
+cleanup:
+	minimal_legacy_bpf__destroy(skel);
+	return -err;
+}


### PR DESCRIPTION
As requested in #68 discussion, this PR adds a new minimal_legacy example for running on kernels that do not support global variables.