### PR TITLE
Update profile for the changes of blazesym API.

### DIFF
--- a/examples/c/profile.c
+++ b/examples/c/profile.c
@@ -28,19 +28,19 @@ static void show_stack_trace(__u64 *stack, int stack_sz, pid_t pid)
 {
 	const struct blazesym_result *result;
 	const struct blazesym_csym *sym;
-	sym_file_cfg cfg;
+	sym_src_cfg src;
 	int i, j;
 
 	if (pid) {
-		cfg.cfg_type = CFG_T_PROCESS;
-		cfg.params.process.pid = pid;
+		src.src_type = SRC_T_PROCESS;
+		src.params.process.pid = pid;
 	} else {
-		cfg.cfg_type = CFG_T_KERNEL;
-		cfg.params.kernel.kallsyms = NULL;
-		cfg.params.kernel.kernel_image = NULL;
+		src.src_type = SRC_T_KERNEL;
+		src.params.kernel.kallsyms = NULL;
+		src.params.kernel.kernel_image = NULL;
 	}
 
-	result = blazesym_symbolize(symbolizer, &cfg, 1, (const uint64_t *)stack, stack_sz);
+	result = blazesym_symbolize(symbolizer, &src, 1, (const uint64_t *)stack, stack_sz);
 
 	for (i = 0; i < stack_sz; i++) {
 		if (!result || result->size <= i || !result->entries[i].size) {

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "blazesym"
 version = "0.1.0"
-source = "git+https://github.com/ThinkerYzu1/blazesym.git#1e1f48c18da9416e1d4c35ec9bce4ed77019b109"
+source = "git+https://github.com/ThinkerYzu1/blazesym.git#045afed552882e621f3aee3d950b367a1afaf7f6"
 dependencies = [
  "cbindgen",
  "nix 0.24.1",

--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -74,16 +74,16 @@ fn attach_perf_event(
 
 // Pid 0 means a kernel space stack.
 fn show_stack_trace(stack: &[u64], symbolizer: &BlazeSymbolizer, pid: u32) {
-    let cfg = if pid == 0 {
-        SymbolFileCfg::Kernel {
+    let src = if pid == 0 {
+        SymbolSrcCfg::Kernel {
             kallsyms: None,
             kernel_image: None,
         }
     } else {
-        SymbolFileCfg::Process { pid: Some(pid) }
+        SymbolSrcCfg::Process { pid: Some(pid) }
     };
 
-    let syms = symbolizer.symbolize(&[cfg], stack);
+    let syms = symbolizer.symbolize(&[src], stack);
     for i in 0..stack.len() {
         if syms.len() <= i || syms[i].len() == 0 {
             println!("  {} [<{:016x}>]", i, stack[i]);


### PR DESCRIPTION
BlazeSym has API changes before officially releasing v0.1.0.

The major changes are renaming SymbolFileCfg to SymbolSrcCfg and renaming sym_file_cfg to sym_src_cfg.
