### PR TITLE
Fix URLs of the repository of BlazeSym.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/libbpf/bpftool
 [submodule "blazesym"]
 	path = blazesym
-	url = https://github.com/ThinkerYzu1/blazesym.git
+	url = https://github.com/libbpf/blazesym.git

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "blazesym"
 version = "0.1.0"
-source = "git+https://github.com/ThinkerYzu1/blazesym.git#045afed552882e621f3aee3d950b367a1afaf7f6"
+source = "git+https://github.com/libbpf/blazesym.git#885b4d5297c1633444317d439b312626920b5486"
 dependencies = [
  "cbindgen",
  "nix 0.24.1",

--- a/examples/rust/profile/Cargo.toml
+++ b/examples/rust/profile/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-2.0 OR BSD-3-Clause"
 [dependencies]
 libbpf-rs = "0.14.0"
 nix = "0.24.1"
-blazesym = { git = "https://github.com/ThinkerYzu1/blazesym.git", features = ["cheader"] }
+blazesym = { git = "https://github.com/libbpf/blazesym.git", features = ["cheader"] }
 libc = "*"
 clap = { version = "3.1.18", features = ["derive"] }
 


### PR DESCRIPTION
BlazeSym moved to a new location, but still on githbu.  Although
github would redirect to the new location automatically, we still
change URLs to the new location just in case.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>