### PR TITLE
examples/c: add socket filter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ please check `ipproto_mapping` of `examples/c/sockfilter.c` for the supported pr
 
 ```shell
 $ sudo ./sockfilter
-protocol: UDP   127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
-protocol: UDP   127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
+interface:lo    protocol: UDP   127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
+interface:lo    protocol: UDP   127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
 ```
 
 # Building

--- a/README.md
+++ b/README.md
@@ -252,16 +252,11 @@ protocol, src IP, src port, dst IP, dst port in standard output.
 Currently, most of the IPv4 protocols defined in `uapi/linux/in.h` are included,
 please check `ipproto_mapping` of `examples/c/sockfilter.c` for the supported protocols.
 
-
-
 ```shell
 $ sudo ./sockfilter
-protocol: UDP
-127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
-protocol: UDP
-127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
+protocol: UDP   127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
+protocol: UDP   127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
 ```
-
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
             usdt-1919077 [005] d..21 537311.886227: bpf_trace_printk: USDT manual attach to libc:setjmp: arg1 = 55d03d6a42a0, arg2 = 0, arg3 = 55d03d65e54e
 ```
 
-# Fentry
+## Fentry
 
 `fentry` is an example that uses fentry and fexit BPF programs for tracing. It
 attaches `fentry` and `fexit` traces to `do_unlinkat()` which is called when a
@@ -172,7 +172,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
               rm-9290    [004] d..2  4637.798843: bpf_trace_printk: fexit: pid = 9290, filename = test_file2, ret = 0
 ```
 
-# Kprobe
+## Kprobe
 
 `kprobe` is an example of dealing with kernel-space entry and exit (return)
 probes, `kprobe` and `kretprobe` in libbpf lingo. It attaches `kprobe` and
@@ -198,7 +198,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
               rm-9346    [005] d..4  4710.951895: bpf_trace_printk: KPROBE EXIT: ret = 0
 ```
 
-# XDP
+## XDP
 
 `xdp` is an example written in Rust (using libbpf-rs). It attaches to
 the ingress path of networking device and logs the size of each packet,
@@ -221,7 +221,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
            <...>-2813507 [000] d.s1 602386.696735: bpf_trace_printk: packet size: 66
 ```
 
-# Profile
+## Profile
 
 `profile` is an example written in Rust and C with BlazeSym. It
 attaches to perf events, sampling on every processor periodically. It
@@ -242,6 +242,26 @@ No Userspace Stack
 ```
 
 C version and Rust version show the same content.  Both of them use BlazeSym to symbolize stacktraces.
+
+## Socket filter
+
+`sockfilter` is an example of monitoring packet and dealing with `__sk_buff`
+structure. It attaches `socket` BPF program to `sock_queue_rcv_skb()` function
+and retrieve information from `BPF_MAP_TYPE_RINGBUF`, then print
+protocol, src IP, src port, dst IP, dst port in standard output.
+Currently, most of the IPv4 protocols defined in `uapi/linux/in.h` are included,
+please check `ipproto_mapping` of `examples/c/sockfilter.c` for the supported protocols.
+
+
+
+```shell
+$ sudo ./sockfilter
+protocol: UDP
+127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
+protocol: UDP
+127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
+```
+
 
 # Building
 

--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -19,7 +19,7 @@ INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
 CFLAGS := -g -Wall
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
 
-APPS = minimal minimal_legacy bootstrap uprobe kprobe fentry usdt
+APPS = minimal minimal_legacy bootstrap uprobe kprobe fentry usdt sockfilter
 
 CARGO ?= $(shell which cargo)
 ifeq ($(strip $(CARGO)),)

--- a/examples/c/sockfilter.bpf.c
+++ b/examples/c/sockfilter.bpf.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+#include <stddef.h>
+#define IP_MF		0x2000
+#define IP_OFFSET	0x1FFF
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 256 * 1024);
+} rb SEC(".maps");
+
+struct so_event {
+	__be32 src_addr;
+	__be32 dst_addr;
+	union {
+		__be32 ports;
+		__be16 port16[2];
+	};
+	__u32 ip_proto;
+	__u32 pkt_type;
+};
+
+static inline int ip_is_fragment(struct __sk_buff *skb, __u32 nhoff)
+{
+	__u16 frag_off;
+	bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, frag_off), &frag_off, 2);
+	frag_off = __bpf_ntohs(frag_off);
+	return frag_off & (IP_MF | IP_OFFSET);
+}
+
+SEC("socket")
+int socket_handler(struct __sk_buff *skb)
+{
+	struct so_event *e;
+	__u8 verlen;
+	__u16 proto;
+	__u32 nhoff = ETH_HLEN;
+
+	bpf_skb_load_bytes(skb, 12, &proto, 2);
+	proto = __bpf_ntohs(proto);
+	if (proto != ETH_P_IP)
+		return 0;
+
+	if (ip_is_fragment(skb, nhoff))
+		return 0;
+
+	/* reserve sample from BPF ringbuf */
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e)
+		return 0;
+
+	bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, protocol), &e->ip_proto, 1);
+
+	if (e->ip_proto != IPPROTO_GRE) {
+		bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, saddr), &(e->src_addr), 4);
+		bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, daddr), &(e->dst_addr), 4);
+	}
+
+	bpf_skb_load_bytes(skb, nhoff + 0, &verlen, 1);
+	bpf_skb_load_bytes(skb, nhoff + ((verlen & 0xF) << 2), &(e->ports), 4);
+	e->pkt_type = skb->pkt_type;
+	bpf_ringbuf_submit(e, 0);
+
+	return skb->len;
+}

--- a/examples/c/sockfilter.bpf.c
+++ b/examples/c/sockfilter.bpf.c
@@ -7,6 +7,8 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 #include <stddef.h>
+#include "sockfilter.h"
+
 #define IP_MF		0x2000
 #define IP_OFFSET	0x1FFF
 
@@ -17,20 +19,10 @@ struct {
 	__uint(max_entries, 256 * 1024);
 } rb SEC(".maps");
 
-struct so_event {
-	__be32 src_addr;
-	__be32 dst_addr;
-	union {
-		__be32 ports;
-		__be16 port16[2];
-	};
-	__u32 ip_proto;
-	__u32 pkt_type;
-};
-
 static inline int ip_is_fragment(struct __sk_buff *skb, __u32 nhoff)
 {
 	__u16 frag_off;
+
 	bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, frag_off), &frag_off, 2);
 	frag_off = __bpf_ntohs(frag_off);
 	return frag_off & (IP_MF | IP_OFFSET);

--- a/examples/c/sockfilter.bpf.c
+++ b/examples/c/sockfilter.bpf.c
@@ -59,6 +59,7 @@ int socket_handler(struct __sk_buff *skb)
 	bpf_skb_load_bytes(skb, nhoff + 0, &verlen, 1);
 	bpf_skb_load_bytes(skb, nhoff + ((verlen & 0xF) << 2), &(e->ports), 4);
 	e->pkt_type = skb->pkt_type;
+	e->ifindex = skb->ifindex;
 	bpf_ringbuf_submit(e, 0);
 
 	return skb->len;

--- a/examples/c/sockfilter.c
+++ b/examples/c/sockfilter.c
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#include <arpa/inet.h>
+#include <assert.h>
+#include <bpf/libbpf.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include "sockfilter.skel.h"
+
+struct so_event {
+	__be32 src_addr;
+	__be32 dst_addr;
+	union {
+		__be32 ports;
+		__be16 port16[2];
+	};
+	__u32 ip_proto;
+	__u32 pkt_type;
+};
+
+static const char * ipproto_mapping[IPPROTO_MAX] = {
+	[IPPROTO_IP] = "IP",
+	[IPPROTO_ICMP] = "ICMP",
+	[IPPROTO_IGMP] = "IGMP",
+	[IPPROTO_IPIP] = "IPIP",
+	[IPPROTO_TCP] = "TCP",
+	[IPPROTO_EGP] = "EGP",
+	[IPPROTO_PUP] = "PUP",
+	[IPPROTO_UDP] = "UDP",
+	[IPPROTO_IDP] = "IDP",
+	[IPPROTO_TP] = "TP",
+	[IPPROTO_DCCP] = "DCCP",
+	[IPPROTO_IPV6] = "IPV6",
+	[IPPROTO_RSVP] = "RSVP",
+	[IPPROTO_GRE] = "GRE",
+	[IPPROTO_ESP] = "ESP",
+	[IPPROTO_AH] = "AH",
+	[IPPROTO_MTP] = "MTP",
+	[IPPROTO_BEETPH] = "BEETPH",
+	[IPPROTO_ENCAP] = "ENCAP",
+	[IPPROTO_PIM] = "PIM",
+	[IPPROTO_COMP] = "COMP",
+	[IPPROTO_SCTP] = "SCTP",
+	[IPPROTO_UDPLITE] = "UDPLITE",
+	[IPPROTO_MPLS] = "MPLS",
+	[IPPROTO_RAW] = "RAW"
+};
+
+static inline int open_raw_sock(const char *name) {
+	struct sockaddr_ll sll;
+	int sock;
+
+	sock = socket(PF_PACKET, SOCK_RAW | SOCK_NONBLOCK | SOCK_CLOEXEC,
+				htons(ETH_P_ALL));
+	if (sock < 0) {
+		printf("cannot create raw socket\n");
+		return -1;
+	}
+
+	memset(&sll, 0, sizeof(sll));
+	sll.sll_family = AF_PACKET;
+	sll.sll_ifindex = if_nametoindex(name);
+	sll.sll_protocol = htons(ETH_P_ALL);
+	if (bind(sock, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+		printf("bind to %s: %s\n", name, strerror(errno));
+		close(sock);
+		return -1;
+	}
+
+	return sock;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+
+static int handle_event(void *ctx, void *data, size_t data_sz) {
+	const struct so_event *e = data;
+
+	if (e->pkt_type != PACKET_HOST)
+		return 0;
+
+	if (e->ip_proto < 0 || e->ip_proto >= IPPROTO_MAX)
+		return 0;
+
+	printf("protocol: %s\n%s:%d(src) -> %s:%d(dst)\n",
+		ipproto_mapping[e->ip_proto],
+		inet_ntoa((struct in_addr){e->src_addr}),
+		ntohs(e->port16[0]),
+		inet_ntoa((struct in_addr){e->dst_addr}),
+		ntohs(e->port16[1])
+	);
+	return 0;
+}
+
+int main(int argc, char **argv) {
+	struct ring_buffer *rb = NULL;
+	struct sockfilter_bpf *skel;
+	int err, prog_fd, sock;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Open BPF application */
+	skel = sockfilter_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	/* Load & verify BPF programs */
+	err = sockfilter_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+		goto cleanup;
+	}
+
+	/* Attach tracepoint handler */
+	err = sockfilter_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+
+	/* Set up ring buffer polling */
+	rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event, NULL, NULL);
+	if (!rb) {
+		err = -1;
+		fprintf(stderr, "Failed to create ring buffer\n");
+		goto cleanup;
+	}
+
+	/* attach raw socket TO BPF */
+	prog_fd = bpf_program__fd(skel->progs.socket_handler);
+	sock = open_raw_sock("lo");
+	if (sock < 0) {
+		err = -2;
+		fprintf(stderr, "Failed to open raw socket\n");
+		goto cleanup;
+	}
+
+	if (setsockopt(sock, SOL_SOCKET, SO_ATTACH_BPF, &prog_fd,
+		sizeof(prog_fd))) {
+		err = -2;
+		fprintf(stderr, "Failed to attach raw socket\n");
+		goto cleanup;
+	}
+
+	/* Process events */
+	for (;;) {
+		err = ring_buffer__poll(rb, 100 /* timeout, ms */);
+		/* Ctrl-C will cause -EINTR */
+		if (err == -EINTR) {
+			err = 0;
+			break;
+		}
+		if (err < 0) {
+			printf("Error polling perf buffer: %d\n", err);
+			break;
+		}
+		sleep(1);
+	}
+
+cleanup:
+	ring_buffer__free(rb);
+	sockfilter_bpf__destroy(skel);
+	return -err;
+}

--- a/examples/c/sockfilter.c
+++ b/examples/c/sockfilter.c
@@ -76,6 +76,7 @@ static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va
 static int handle_event(void *ctx, void *data, size_t data_sz)
 {
 	const struct so_event *e = data;
+	char ifname[IF_NAMESIZE];
 
 	if (e->pkt_type != PACKET_HOST)
 		return 0;
@@ -83,7 +84,11 @@ static int handle_event(void *ctx, void *data, size_t data_sz)
 	if (e->ip_proto < 0 || e->ip_proto >= IPPROTO_MAX)
 		return 0;
 
-	printf("protocol: %s\t%s:%d(src) -> %s:%d(dst)\n",
+	if (!if_indextoname(e->ifindex, ifname))
+		return 0;
+
+	printf("interface: %s\tprotocol: %s\t%s:%d(src) -> %s:%d(dst)\n",
+		ifname,
 		ipproto_mapping[e->ip_proto],
 		inet_ntoa((struct in_addr){e->src_addr}),
 		ntohs(e->port16[0]),

--- a/examples/c/sockfilter.h
+++ b/examples/c/sockfilter.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#ifndef __SOCKFILTER_H
+#define __SOCKFILTER_H
+
+struct so_event {
+	__be32 src_addr;
+	__be32 dst_addr;
+	union {
+		__be32 ports;
+		__be16 port16[2];
+	};
+	__u32 ip_proto;
+	__u32 pkt_type;
+	__u32 ifindex;
+};
+
+
+#endif /* __SOCKFILTER_H */


### PR DESCRIPTION
This is a simplified example I port from linux `samples/bpf` directory, many code snippet came from there.

In this example, I opened a `SOCK_RAW` socket in `lo` interface, then attach it to the bpf program for monitoring.

I use `BPF_MAP_TYPE_RINGBUF` to carry information back to user space program, and the user space program will print formatted information to stdout, for example:
```
interface:lo    protocol: UDP   127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
interface:lo    protocol: UDP   127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
```

Currently, most of the IPv4 protocols defined in `uapi/linux/in.h` are included, please check `ipproto_mapping` for the supported protocols.

Another thing to be done is that we need to add another linux uapi header into `libbpf` submodule :  `uapi/linux/ip.h`, because we need to retrieve `protocol`, `saddr` and `daddr` from `struct ip_hdr`.

I will temporarily mark this PR as draft, please give me some suggestions for this, thank you!