### PR TITLE
tools: Fix cmake ARCH error for aarch64 etc.

### DIFF
--- a/tools/cmake/FindBpfObject.cmake
+++ b/tools/cmake/FindBpfObject.cmake
@@ -141,7 +141,7 @@ endif()
 
 # Get target arch
 execute_process(COMMAND uname -m
-  COMMAND sed "s/x86_64/x86/"
+  COMMAND sed -e "s/x86_64/x86/" -e "s/aarch64/arm64/" -e "s/ppc64le/powerpc/" -e "s/mips.*/mips/"
   OUTPUT_VARIABLE ARCH_output
   ERROR_VARIABLE ARCH_error
   RESULT_VARIABLE ARCH_result


### PR DESCRIPTION
According to #104, cmake can not get a correct ARCH (such as arm64 for aarch64 platform) and raise an GCC error("Must specify a BPF target arch via __TARGET_ARCH_xxx") when target platform is aarch64 or some else. This PR is going to fix it.