### PR TITLE
cmake: Fix btf header missing in legacy kernel env. 

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -19,7 +19,7 @@ ExternalProject_Add(libbpf
     INCLUDEDIR=
     LIBDIR=
     UAPIDIR=
-    install
+    install install_uapi_headers
   BUILD_IN_SOURCE TRUE
   INSTALL_COMMAND ""
   STEP_TARGETS build


### PR DESCRIPTION
If include `<bpf/btf.h>` and compile with CMake on some machines with legacy kernels, you may hit this error:
```
src/build/libbpf/bpf/btf.h:10:10: fatal error: linux/btf.h: No such file or directory
#include <linux/btf.h>
^~~~~~~~~~~~~
compilation terminated.
```
I think it's due to `../../libbpf/include/uapi` not includes as it is at [Makefile#L18](https://github.com/libbpf/libbpf-bootstrap/blob/c58877bf5895dd5015550d4624f68a6ff0ed4b33/examples/c/Makefile#L18)

After the fix, a dir containing uapi headers will be created under the `build` dir
```
$ ls build/libbpf/linux
bpf_common.h  bpf.h  btf.h                                                                        
```