### PR TITLE
Make ARCH configurable.

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -10,7 +10,7 @@ BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
 LIBBLAZESYM_SRC := $(abspath ../../blazesym/)
 LIBBLAZESYM_OBJ := $(abspath $(OUTPUT)/libblazesym.a)
 LIBBLAZESYM_HEADER := $(abspath $(OUTPUT)/blazesym.h)
-ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
 VMLINUX := ../../vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or


### PR DESCRIPTION
Doing cross-compilation (issue #140) need a way to specify the target platform.  However, the makefile also detects architecture by calling `uname` on the building machine.  This patch lets users to config it by defining ARCH.  For example, 'make ARCH=arm64' will build against arm64 as the target platform.

Signed-off-by: Kui-Feng Lee <kuifeng@meta.com>