### PR TITLE
cmake: fix missing dependency on bpftool build

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(app ${apps})
 
   # Build object skeleton and depend skeleton on libbpf build
   bpf_object(${app_stem} ${app_stem}.bpf.c)
-  add_dependencies(${app_stem}_skel libbpf-build)
+  add_dependencies(${app_stem}_skel libbpf-build bpftool-build)
 
   add_executable(${app_stem} ${app_stem}.c)
   target_link_libraries(${app_stem} ${app_stem}_skel)


### PR DESCRIPTION
application build requires bpftool or it fails like this:

```
bash: line 1: libbpf-bootstrap/examples/c/build/bpftool/bootstrap/bpftool:
No such file or directory
```

add bpftool build to the dependency list of the application build to fix it.

Signed-off-by: runsisi <runsisi@hust.edu.cn>