### PR TITLE
ci: add llvm 17 build test and fix CI for llvm 16

### DIFF
--- a/.github/docker/Dockerfile.ubuntu
+++ b/.github/docker/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ ENV LLVM_VERSION=$LLVM_VERSION
 ARG SHORTNAME="jammy"
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN if [ "${LLVM_VERSION}" = "16" ]; \
+RUN if [ "${LLVM_VERSION}" = "17" ]; \
     then \
         echo "\n\
 deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [14, 15, 16]
+        llvm: [14, 15, 16, 17]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Upstream llvm moved to 17, so we need to accommodate 16 as being not the latest version. Also add another build step for validating llvm 17.