### PR TITLE
Use local blazesym snapshot for Rust examples

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "atty"
@@ -58,9 +58,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "blazesym"
 version = "0.1.0"
-source = "git+https://github.com/libbpf/blazesym.git#d954f73867527dc75025802160c759d0b6a0641f"
 dependencies = [
+ "anyhow",
  "cbindgen",
+ "crossbeam-channel",
+ "libc",
  "nix 0.24.2",
  "regex",
 ]
@@ -186,6 +188,25 @@ name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -330,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"

--- a/examples/rust/profile/Cargo.toml
+++ b/examples/rust/profile/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-2.0 OR BSD-3-Clause"
 [dependencies]
 libbpf-rs = "0.19"
 nix = "0.24.1"
-blazesym = { git = "https://github.com/libbpf/blazesym.git", features = ["cheader"] }
+blazesym = { path = "../../../blazesym", features = ["cheader", "dont-generate-test-files"] }
 libc = "*"
 clap = { version = "3.1.18", features = ["derive"] }
 


### PR DESCRIPTION
We already pull in a snapshot of blazesym for the generation of C headers and the creation of a library.
Let's also use that in the Rust examples, instead of reaching out to `crates.io`, to use the same baseline everywhere.