### PR TITLE
examples/c: Fix Makefile for aarch64

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -11,10 +11,10 @@ LIBBLAZESYM_SRC := $(abspath ../../blazesym/)
 LIBBLAZESYM_OBJ := $(abspath $(OUTPUT)/libblazesym.a)
 LIBBLAZESYM_HEADER := $(abspath $(OUTPUT)/blazesym.h)
 ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
 			 | sed 's/aarch64/arm64/' \
 			 | sed 's/ppc64le/powerpc/' \
 			 | sed 's/mips.*/mips/' \
-			 | sed 's/arm.*/arm/' \
 			 | sed 's/riscv64/riscv/')
 VMLINUX := ../../vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with


### PR DESCRIPTION
On aarch64, C examples accidentally include arm/vmlinux.h and cause runtime error. Reorder the sed commands to avoid the issue.