### PR TITLE
examples/c: make CLANG_BPF_SYS_INCLUDES substitutable

### DIFF
--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -44,7 +44,7 @@ endif
 #
 # Use '-idirafter': Don't interfere with include mechanics except where the
 # build would have failed anyways.
-CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+CLANG_BPF_SYS_INCLUDES ?= $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
 ifeq ($(V),1)


### PR DESCRIPTION
Sometimes it's necessary to replace `CLANG_BPF_SYS_INCLUDES` by another value when build platform differs from host. For example, we can do something like this in Buildroot package for `libbpf-bootstrap`:

    make ... CLANG_BPF_SYS_INCLUDES="$(STAGING_DIR)/usr/include"

Otherwise, clang uses host's Linux headers instead of target's.