### PR TITLE
Minimal Example fix for pid problem in process namespaces envs like containers or WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
 `minimal` is great as a bare-bones experimental playground to quickly try out
 new ideas or BPF features.
 
+## Minimal_ns
+
+`minimal_ns` is as same as `minimal` but for namespaced environments.
+`minimal` would not work in environments that have namespace, like containers, or WSL2, 
+Cause the perceived pid of the process in the namespace is not the actual pid of the
+process. for executing `minimal` in namespaced environments like containers or wsl2 you
+need to use `minimal_namespaced` instead.
+
+```shell
+$ cd examples/c
+$ make minimal_ns
+$ sudo ./minimal_ns
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+           <...>-3840345 [022] d...1  8804.331204: bpf_trace_printk: BPF triggered from PID 9087.
+           <...>-3840345 [022] d...1  8804.331215: bpf_trace_printk: BPF triggered from PID 9087.
+```
+
 ## Minimal_Legacy
 
 This version of `minimal` is modified to allow running on even older kernels

--- a/examples/c/minimal_ns.bpf.c
+++ b/examples/c/minimal_ns.bpf.c
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2023 Hosein Bakhtiari */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <linux/sched.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+int my_pid = 0;
+unsigned long long dev;
+unsigned long long ino;
+
+SEC("tp/syscalls/sys_enter_write")
+int handle_tp(void *ctx)
+{
+	struct bpf_pidns_info ns;
+
+	bpf_get_ns_current_pid_tgid(dev, ino, &ns, sizeof(ns));
+	if (ns.pid != my_pid)
+		return 0;
+
+	bpf_printk("BPF triggered from PID %d.\n", ns.pid);
+
+	return 0;
+}

--- a/examples/c/minimal_ns.c
+++ b/examples/c/minimal_ns.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2023 Hosein Bakhtiari */
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <bpf/libbpf.h>
+#include "minimal_ns.skel.h"
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+int main(int argc, char **argv)
+{
+	struct minimal_ns_bpf *skel;
+	int err;
+	struct stat sb;
+
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Open BPF application */
+	skel = minimal_ns_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	/* ensure BPF program only handles write() syscalls from our process */
+	if (stat("/proc/self/ns/pid", &sb) == -1) {
+		fprintf(stderr, "Failed to acquire namespace information");
+		return 1;
+	}
+	skel->bss->dev = sb.st_dev;
+	skel->bss->ino = sb.st_ino;
+	skel->bss->my_pid = getpid();
+
+	/* Load & verify BPF programs */
+	err = minimal_ns_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+		goto cleanup;
+	}
+
+	/* Attach tracepoint handler */
+	err = minimal_ns_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
+
+	for (;;) {
+		/* trigger our BPF program */
+		fprintf(stderr, ".");
+		sleep(1);
+	}
+
+cleanup:
+	minimal_ns_bpf__destroy(skel);
+	return -err;
+}


### PR DESCRIPTION
Currently minimal example does not work in environments which are inside a process namespace, like docker containers or WSL2, because the pid of the `minimal` process inside the userspace is not equal to `tgid` of that process in the bpf.

this is the fix.