### PR TITLE
Avoid profiling offline or not present CPUs

### DIFF
--- a/examples/c/profile.h
+++ b/examples/c/profile.h
@@ -13,6 +13,11 @@
 
 typedef __u64 stack_trace_t[MAX_STACK_DEPTH];
 
+/* This function is from libbpf, but it is not a public API and can only be
+used for demonstration, because we statically link against the libbpf
+submodule during build */
+extern int parse_cpu_mask_file(const char *fcpu, bool **mask, int *mask_sz);
+
 struct stacktrace_event {
 	__u32 pid;
 	__u32 cpu_id;


### PR DESCRIPTION
In the current implementation, if I try to run `example/c/profile` in a virtual machine, `libbpf_num_possible_cpus` will get the wrong number of CPUs, causing the program to exit and throw an error: `Fail to set up performance monitor on a CPU/Core` because the wrong CPU id is passed to `syscall` and throwing `No such device`

The Rust version (`example/rust/profile`) of the implementation ignores this error and continues to execute `bpf_program__attach_perf_event`, which throws `invalid perf event FD -1`, but profile can still be used because `bpf_program__attach_perf_event handles` the case of passing the wrong CPU id.

This fix has only been applied to the C(`example/c/profile`).