### PR TITLE
fix: sockfilter example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Currently, most of the IPv4 protocols defined in `uapi/linux/in.h` are included,
 please check `ipproto_mapping` of `examples/c/sockfilter.c` for the supported protocols.
 
 ```shell
-$ sudo ./sockfilter
+$ sudo ./sockfilter -i <interface>
 interface:lo    protocol: UDP   127.0.0.1:51845(src) -> 127.0.0.1:53(dst)
 interface:lo    protocol: UDP   127.0.0.1:41552(src) -> 127.0.0.1:53(dst)
 ```


### PR DESCRIPTION
When we have multiple calls to `inet_ntoa()`, this function might return the same char* even though the underlying string has been modified.

We'll get the same string if we use this function in a row in a single printf function(because char* pointed to the same location).

On the other hand, support `-i <interface>` option in sockfilter program.