### PR TITLE
fix: profile build issue with cmake

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CARGO_EXISTS)
     PREFIX blazesym
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build --features=cheader --release
+    BUILD_COMMAND cargo build --release
     BUILD_IN_SOURCE TRUE
     INSTALL_COMMAND ""
     STEP_TARGETS build
@@ -89,7 +89,7 @@ foreach(app ${apps})
   target_link_libraries(${app_stem} ${app_stem}_skel)
   if(${app_stem} STREQUAL profile)
     target_include_directories(${app_stem} PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/target/release/)
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/include)
     target_link_libraries(${app_stem}
       ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/target/release/libblazesym.a -lpthread -lrt -ldl)
   endif()


### PR DESCRIPTION
When CARGO exists external project `blazesym` will build,  It not works with `--features=cheader` option. `profile` depends on `blazesym`, correct `blazesym` include directories.