### PR TITLE
ci: add llvm-18 tests

### DIFF
--- a/.github/docker/Dockerfile.ubuntu
+++ b/.github/docker/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ ARG SHORTNAME="jammy"
 ENV SHORTNAME=$SHORTNAME
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN if [ "${LLVM_VERSION}" = "17" ]; \
+RUN if [ "${LLVM_VERSION}" = "18" ]; \
     then \
         echo "\n\
 deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [11, 12, 13, 14, 15, 16, 17]
+        llvm: [11, 12, 13, 14, 15, 16, 17, 18]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
LLVM/Clang 18 is available now, run against it as well. This also should fix current LLVM 17 failure, which assumes LLVM 17 is the latest one.