### PR TITLE
example/c: fix uprobe cross compiling issue

### DIFF
--- a/examples/c/uprobe.bpf.c
+++ b/examples/c/uprobe.bpf.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 /* Copyright (c) 2020 Facebook */
-#include <linux/bpf.h>
-#include <linux/ptrace.h>
+#include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 


### PR DESCRIPTION
Some archs, like arm64, use userspace pt_regs in bpf_tracing.h. When cross compiling arm64 bpf examples in x86_64 host, clang cannot find the arch specific uapi ptrace.h, which causing below compiling errror,

"
uprobe.bpf.c:11:5: error: incomplete definition of type 'struct user_pt_regs'
   11 | int BPF_KPROBE(uprobe_add, int a, int b)
 "

Using arch specific vmlinux.h fix this issue.