### PR TITLE
c/usdt: fix a compiling error

### DIFF
--- a/examples/c/usdt.bpf.c
+++ b/examples/c/usdt.bpf.c
@@ -5,7 +5,7 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/usdt.bpf.h>
 
-pid_t my_pid;
+pid_t my_pid = 0;
 
 SEC("usdt/libc.so.6:libc:setjmp")
 int BPF_USDT(usdt_auto_attach, void *arg1, int arg2, void *arg3)


### PR DESCRIPTION
Fix 'libbpf: failed to find BTF info for global/extern symbol' since uninitialized global variables on Ubuntu 20.04.6 with clang 10. 
I was able to compile on a newer ubuntu with a higher version of clang. 
However, on a development module (nVidia Orin AGX) running Ubuntu 20.04.6 LTS with clang version 10.0.0-4ubuntu1, it is not possible to use apt to update clang to a new version. Downloading the source code of a higher version of clang for compilation is cumbersome. 
So I hope that with the change, the project code can be easily compiled and used in earlier os.