### PR TITLE
build.yml for Android xmake build

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,31 @@
+name: libbpf-bootstrap android ubuntu_latest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build_libbpf_bootstrap_android:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [armeabi-v7a, x86_64]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: xmake-io/github-action-setup-xmake@v1
+      with:
+        xmake-version: 'latest'
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update -y && sudo apt-get install -yqq \
+          build-essential clang llvm libelf1 libelf-dev zlib1g-dev libc++-dev libc++abi-dev \
+          sudo \
+          && sudo apt-get -y clean
+    - name: Build xmake android examples/c
+      run: |
+        cd examples/c && xmake f -p android -a ${{ matrix.arch }} -m release -y && xmake -y


### PR DESCRIPTION
Covering Android builds for armv7a and x86_64.

Currently failing with errors mentioned by several users (https://github.com/libbpf/bpftool/issues/120)

Getting the error at compile stage:

```
[ 12%]: compiling.bpf uprobe.bpf.c
[ 12%]: compiling.bpf bootstrap.bpf.c
[ 12%]: compiling.bpf minimal_legacy.bpf.c
libbpf: map 'my_pid_map': unsupported map linkage static.
Error: failed to open BPF object file: Operation not supported
error: execv(bpftool gen skeleton build/.gens/minimal_legacy/android/x86_64/release/rules/bpf/minimal_legacy.bpf.o) failed(161)
Error: Process completed with exit code 255
```