### PR TITLE
deps: update blazesym submodule to v0.2.0-alpha.8

### DIFF
--- a/examples/c/profile.c
+++ b/examples/c/profile.c
@@ -71,16 +71,16 @@ static void show_stack_trace(__u64 *stack, int stack_sz, pid_t pid)
 		struct blaze_symbolize_src_process src = {
 			.pid = pid,
 		};
-		result = blaze_symbolize_process(symbolizer, &src, (const uintptr_t *)stack, stack_sz);
+		result = blaze_symbolize_process_virt_addrs(symbolizer, &src, (const uintptr_t *)stack, stack_sz);
 	} else {
 		struct blaze_symbolize_src_kernel src = {};
-		result = blaze_symbolize_kernel(symbolizer, &src, (const uintptr_t *)stack, stack_sz);
+		result = blaze_symbolize_kernel_virt_addrs(symbolizer, &src, (const uintptr_t *)stack, stack_sz);
 	}
 
 
 	for (i = 0; i < stack_sz; i++) {
 		if (!result || result->cnt <= i || result->syms[i].name == NULL) {
-			printf(" %2d [<%016llx>]\n", i, stack[i]);
+			printf("%016llx: <no-symbol>\n", stack[i]);
 			continue;
 		}
 

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,12 +16,6 @@ checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "ansi_term"
@@ -80,12 +63,11 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-alpha.7"
+version = "0.2.0-alpha.8"
 dependencies = [
  "cpp_demangle",
  "gimli",
  "libc",
- "lru",
  "rustc-demangle",
  "tracing",
 ]
@@ -323,10 +305,6 @@ name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -487,15 +465,6 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-
-[[package]]
-name = "lru"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
-dependencies = [
- "hashbrown 0.14.1",
-]
 
 [[package]]
 name = "matchers"

--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -126,7 +126,7 @@ fn show_stack_trace(stack: &[u64], symbolizer: &symbolize::Symbolizer, pid: u32)
         symbolize::Source::from(symbolize::Process::new(pid.into()))
     };
 
-    let syms = match symbolizer.symbolize(&src, stack) {
+    let syms = match symbolizer.symbolize(&src, symbolize::Input::AbsAddr(stack)) {
         Ok(syms) => syms,
         Err(err) => {
             eprintln!("  failed to symbolize addresses: {err:#}");


### PR DESCRIPTION
Update the `blazesym` submodule to version `0.2.0-alpha.8`.