### PR TITLE
Add an LSM BPF sample program

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,33 @@ Task Info. Pid: 1600497. Process Name: tmux: server. Kernel Stack Len: 0. State:
 Task Info. Pid: 1600498. Process Name: bash. Kernel Stack Len: 5. State: INTERRUPTIBLE
 ```
 
+## lsm
+`lsm` serves as an illustrative example of utilizing [LSM BPF](https://docs.kernel.org/bpf/prog_lsm.html). In this example, the `bpf()` system call is effectively blocked. Once the `lsm` program is operational, its successful execution can be confirmed by using the `bpftool prog list` command.
+
+```shell
+$ sudo ./lsm
+libbpf: loading object 'lsm_bpf' from buffer
+...
+Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` to see output of the BPF programs.
+..........
+```
+
+The output from `lsm` in `/sys/kernel/debug/tracing/trace_pipe` is expected to resemble the following:
+
+````shell
+$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+         bpftool-70646   [002] ...11 279318.416393: bpf_trace_printk: LSM: block bpf() worked
+         bpftool-70646   [002] ...11 279318.416532: bpf_trace_printk: LSM: block bpf() worked
+         bpftool-70646   [002] ...11 279318.416533: bpf_trace_printk: LSM: block bpf() worked
+````
+
+When the `bpf()` system call gets blocked, the `bpftool prog list` command yields the following output:
+
+```shell
+$ sudo bpftool prog list
+Error: can't get next program: Operation not permitted
+```
+
 # Building
 
 libbpf-bootstrap supports multiple build systems that do the same thing.

--- a/examples/c/.gitignore
+++ b/examples/c/.gitignore
@@ -11,5 +11,6 @@
 /tc
 /ksyscall
 /task_iter
+/lsm
 /cmake-build-debug/
 /cmake-build-release/

--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -24,7 +24,7 @@ INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX)) -I$(LIBB
 CFLAGS := -g -Wall
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
 
-APPS = minimal minimal_legacy bootstrap uprobe kprobe fentry usdt sockfilter tc ksyscall task_iter
+APPS = minimal minimal_legacy bootstrap uprobe kprobe fentry usdt sockfilter tc ksyscall task_iter lsm
 
 CARGO ?= $(shell which cargo)
 ifeq ($(strip $(CARGO)),)

--- a/examples/c/lsm.bpf.c
+++ b/examples/c/lsm.bpf.c
@@ -1,0 +1,20 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+#define EPERM  1
+
+SEC("lsm/bpf")
+int BPF_PROG(lsm_bpf, int cmd, union bpf_attr *attr, unsigned int size, int ret)
+{
+    /* ret is the return value from the previous BPF program
+     * or 0 if it's the first hook.
+     */
+    if (ret != 0)
+        return ret;
+
+    bpf_printk("LSM: block bpf() worked");
+    return -EPERM;
+}

--- a/examples/c/lsm.c
+++ b/examples/c/lsm.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2024 David Di */
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include "lsm.skel.h"
+
+/* Notice: Ensure your kernel version is 5.7 or higher, BTF (BPF Type Format) is enabled, 
+ * and the file '/sys/kernel/security/lsm' includes 'bpf'.
+ */
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+int main(int argc, char **argv)
+{
+	struct lsm_bpf *skel;
+	int err;
+
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Open, load, and verify BPF application */
+	skel = lsm_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open and load BPF skeleton\n");
+		goto cleanup;
+	}
+
+	/* Attach lsm handler */
+	err = lsm_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
+
+	for (;;) {
+		/* trigger our BPF program */
+		fprintf(stderr, ".");
+		sleep(1);
+	}
+
+cleanup:
+	lsm_bpf__destroy(skel);
+	return -err;
+}


### PR DESCRIPTION
It requires running on a kernel version >= 5.7 and necessitates the kernel having LSM enabled. For implementation details, please refer to the lsm.c file.