### PR TITLE
examples/rust: Store skeletons in $OUT_DIR

### DIFF
--- a/examples/rust/profile/build.rs
+++ b/examples/rust/profile/build.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::env::consts::ARCH;
+use std::path::Path;
 use std::path::PathBuf;
 
 use libbpf_cargo::SkeletonBuilder;
@@ -12,6 +14,19 @@ fn main() {
 
     SkeletonBuilder::new()
         .source(SRC)
+        .clang_args(format!(
+            "-I{}",
+            Path::new("../../../vmlinux")
+                .join(match ARCH {
+                    "aarch64" => "arm64",
+                    "loongarch64" => "loongarch",
+                    "powerpc64" => "powerpc",
+                    "riscv64" => "riscv",
+                    "x86_64" => "x86",
+                    _ => ARCH,
+                })
+                .display()
+        ))
         .build_and_generate(out)
         .expect("bpf compilation failed");
     println!("cargo:rerun-if-changed={}", SRC);

--- a/examples/rust/profile/build.rs
+++ b/examples/rust/profile/build.rs
@@ -1,25 +1,18 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::env;
+use std::path::PathBuf;
 
-extern crate libbpf_cargo;
 use libbpf_cargo::SkeletonBuilder;
 
-const SRC: &str = "./src/bpf/profile.bpf.c";
+const SRC: &str = "src/bpf/profile.bpf.c";
 
 fn main() {
-    // It's unfortunate we cannot use `OUT_DIR` to store the generated skeleton.
-    // Reasons are because the generated skeleton contains compiler attributes
-    // that cannot be `include!()`ed via macro. And we cannot use the `#[path = "..."]`
-    // trick either because you cannot yet `concat!(env!("OUT_DIR"), "/skel.rs")` inside
-    // the path attribute either (see https://github.com/rust-lang/rust/pull/83366).
-    //
-    // However, there is hope! When the above feature stabilizes we can clean this
-    // all up.
-    create_dir_all("./src/bpf/.output").unwrap();
-    let skel = Path::new("./src/bpf/.output/profile.skel.rs");
+    let mut out =
+        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
+    out.push("profile.skel.rs");
+
     SkeletonBuilder::new()
         .source(SRC)
-        .build_and_generate(skel)
+        .build_and_generate(out)
         .expect("bpf compilation failed");
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/rust/profile/src/bpf/vmlinux.h
+++ b/examples/rust/profile/src/bpf/vmlinux.h
@@ -1,1 +1,0 @@
-../../../../../vmlinux/vmlinux.h

--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -19,8 +19,9 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::FmtSubscriber;
 
-#[path = "bpf/.output/profile.skel.rs"]
-mod profile;
+mod profile {
+    include!(concat!(env!("OUT_DIR"), "/profile.skel.rs"));
+}
 mod syscall;
 
 use profile::*;

--- a/examples/rust/tracecon/build.rs
+++ b/examples/rust/tracecon/build.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::env::consts::ARCH;
+use std::path::Path;
 use std::path::PathBuf;
 
 use libbpf_cargo::SkeletonBuilder;
@@ -12,6 +14,19 @@ fn main() {
 
     SkeletonBuilder::new()
         .source(SRC)
+        .clang_args(format!(
+            "-I{}",
+            Path::new("../../../vmlinux")
+                .join(match ARCH {
+                    "aarch64" => "arm64",
+                    "loongarch64" => "loongarch",
+                    "powerpc64" => "powerpc",
+                    "riscv64" => "riscv",
+                    "x86_64" => "x86",
+                    _ => ARCH,
+                })
+                .display()
+        ))
         .build_and_generate(&out)
         .expect("bpf compilation failed");
     println!("cargo:rerun-if-changed={}", SRC);

--- a/examples/rust/tracecon/build.rs
+++ b/examples/rust/tracecon/build.rs
@@ -1,24 +1,18 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::env;
+use std::path::PathBuf;
 
 use libbpf_cargo::SkeletonBuilder;
 
-const SRC: &str = "./src/bpf/tracecon.bpf.c";
+const SRC: &str = "src/bpf/tracecon.bpf.c";
 
 fn main() {
-    // It's unfortunate we cannot use `OUT_DIR` to store the generated skeleton.
-    // Reasons are because the generated skeleton contains compiler attributes
-    // that cannot be `include!()`ed via macro. And we cannot use the `#[path = "..."]`
-    // trick either because you cannot yet `concat!(env!("OUT_DIR"), "/skel.rs")` inside
-    // the path attribute either (see https://github.com/rust-lang/rust/pull/83366).
-    //
-    // However, there is hope! When the above feature stabilizes we can clean this
-    // all up.
-    create_dir_all("./src/bpf/.output").unwrap();
-    let skel = Path::new("./src/bpf/.output/tracecon.skel.rs");
+    let mut out =
+        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
+    out.push("tracecon.skel.rs");
+
     SkeletonBuilder::new()
         .source(SRC)
-        .build_and_generate(&skel)
+        .build_and_generate(&out)
         .expect("bpf compilation failed");
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/rust/tracecon/src/bpf/vmlinux.h
+++ b/examples/rust/tracecon/src/bpf/vmlinux.h
@@ -1,1 +1,0 @@
-../../../../../vmlinux/vmlinux.h

--- a/examples/rust/tracecon/src/main.rs
+++ b/examples/rust/tracecon/src/main.rs
@@ -11,8 +11,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use structopt::StructOpt;
 
-#[path = "bpf/.output/tracecon.skel.rs"]
-mod tracecon;
+mod tracecon {
+    include!(concat!(env!("OUT_DIR"), "/tracecon.skel.rs"));
+}
 use tracecon::*;
 
 type Event = tracecon_bss_types::event;

--- a/examples/rust/xdp/build.rs
+++ b/examples/rust/xdp/build.rs
@@ -1,24 +1,18 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::env;
+use std::path::PathBuf;
 
 use libbpf_cargo::SkeletonBuilder;
 
-const SRC: &str = "./src/bpf/xdppass.bpf.c";
+const SRC: &str = "src/bpf/xdppass.bpf.c";
 
 fn main() {
-    // It's unfortunate we cannot use `OUT_DIR` to store the generated skeleton.
-    // Reasons are because the generated skeleton contains compiler attributes
-    // that cannot be `include!()`ed via macro. And we cannot use the `#[path = "..."]`
-    // trick either because you cannot yet `concat!(env!("OUT_DIR"), "/skel.rs")` inside
-    // the path attribute either (see https://github.com/rust-lang/rust/pull/83366).
-    //
-    // However, there is hope! When the above feature stabilizes we can clean this
-    // all up.
-    create_dir_all("./src/bpf/.output").unwrap();
-    let skel = Path::new("./src/bpf/.output/xdppass.skel.rs");
+    let mut out =
+        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
+    out.push("xdppass.skel.rs");
+
     SkeletonBuilder::new()
         .source(SRC)
-        .build_and_generate(&skel)
+        .build_and_generate(out)
         .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
 }

--- a/examples/rust/xdp/build.rs
+++ b/examples/rust/xdp/build.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::env::consts::ARCH;
+use std::path::Path;
 use std::path::PathBuf;
 
 use libbpf_cargo::SkeletonBuilder;
@@ -12,6 +14,19 @@ fn main() {
 
     SkeletonBuilder::new()
         .source(SRC)
+        .clang_args(format!(
+            "-I{}",
+            Path::new("../../../vmlinux")
+                .join(match ARCH {
+                    "aarch64" => "arm64",
+                    "loongarch64" => "loongarch",
+                    "powerpc64" => "powerpc",
+                    "riscv64" => "riscv",
+                    "x86_64" => "x86",
+                    _ => ARCH,
+                })
+                .display()
+        ))
         .build_and_generate(out)
         .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);

--- a/examples/rust/xdp/src/bpf/vmlinux.h
+++ b/examples/rust/xdp/src/bpf/vmlinux.h
@@ -1,1 +1,0 @@
-../../../../../vmlinux/vmlinux.h

--- a/examples/rust/xdp/src/main.rs
+++ b/examples/rust/xdp/src/main.rs
@@ -5,8 +5,9 @@ use std::{thread, time};
 use anyhow::{bail, Result};
 use structopt::StructOpt;
 
-#[path = "bpf/.output/xdppass.skel.rs"]
-mod xdppass;
+mod xdppass {
+    include!(concat!(env!("OUT_DIR"), "/xdppass.skel.rs"));
+}
 use xdppass::*;
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
Store skeletons in $OUT_DIR as opposed to .output, which is kind of the proper thing to do (though it certainly doesn't help discoverability...) and it is more in line with how examples in libbpf-rs work. Also remove the "there is hope!" comments, because even with https://github.com/rust-lang/rust/pull/83366 resolved we still cannot use the concat! macro in #[path = ...] attributes. All hope is lost.