### PR TITLE
fix missing blazesym head file

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CARGO_EXISTS)
     PREFIX blazesym
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build --release
+    BUILD_COMMAND cargo build --package=blazesym-c --release
     BUILD_IN_SOURCE TRUE
     INSTALL_COMMAND ""
     STEP_TARGETS build
@@ -89,8 +89,8 @@ foreach(app ${apps})
   target_link_libraries(${app_stem} ${app_stem}_skel)
   if(${app_stem} STREQUAL profile)
     target_include_directories(${app_stem} PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/include)
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/capi/include)
     target_link_libraries(${app_stem}
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/target/release/libblazesym.a -lpthread -lrt -ldl)
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../blazesym/target/release/libblazesym_c.a -lpthread -lrt -ldl)
   endif()
 endforeach()


### PR DESCRIPTION
There're some updates in Makefile in commit 4b207312dd. But it's not synchronized into CMakeLists.txt. It causes the error in below.

 77%] Building C object CMakeFiles/profile.dir/profile.c.o
libbpf-bootstrap/examples/c/profile.c:17:10: fatal error: blazesym.h: No such file or directory
   17 | #include "blazesym.h"
      |          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/profile.dir/build.make:84: CMakeFiles/profile.dir/profile.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:520: CMakeFiles/profile.dir/all] Error 2
make: *** [Makefile:91: all] Error 2