### PR TITLE
examples/rust: Use `CARGO_CFG_TARGET_ARCH` environment variable

### DIFF
--- a/examples/rust/profile/build.rs
+++ b/examples/rust/profile/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,18 +11,21 @@ fn main() {
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("profile.skel.rs");
 
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args(format!(
             "-I{}",
             Path::new("../../../vmlinux")
-                .join(match ARCH {
+                .join(match arch.as_ref() {
                     "aarch64" => "arm64",
                     "loongarch64" => "loongarch",
                     "powerpc64" => "powerpc",
                     "riscv64" => "riscv",
                     "x86_64" => "x86",
-                    _ => ARCH,
+                    _ => &arch,
                 })
                 .display()
         ))

--- a/examples/rust/tracecon/build.rs
+++ b/examples/rust/tracecon/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,18 +11,21 @@ fn main() {
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("tracecon.skel.rs");
 
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args(format!(
             "-I{}",
             Path::new("../../../vmlinux")
-                .join(match ARCH {
+                .join(match arch.as_ref() {
                     "aarch64" => "arm64",
                     "loongarch64" => "loongarch",
                     "powerpc64" => "powerpc",
                     "riscv64" => "riscv",
                     "x86_64" => "x86",
-                    _ => ARCH,
+                    _ => &arch,
                 })
                 .display()
         ))

--- a/examples/rust/xdp/build.rs
+++ b/examples/rust/xdp/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::env::consts::ARCH;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,18 +11,21 @@ fn main() {
         PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set in build script"));
     out.push("xdppass.skel.rs");
 
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
+
     SkeletonBuilder::new()
         .source(SRC)
         .clang_args(format!(
             "-I{}",
             Path::new("../../../vmlinux")
-                .join(match ARCH {
+                .join(match arch.as_ref() {
                     "aarch64" => "arm64",
                     "loongarch64" => "loongarch",
                     "powerpc64" => "powerpc",
                     "riscv64" => "riscv",
                     "x86_64" => "x86",
-                    _ => ARCH,
+                    _ => &arch,
                 })
                 .display()
         ))


### PR DESCRIPTION
As per #257, it appears as if `std::env::consts::ARCH` does not get updated to the target architecture in a cross-compilation context. Switch to using the `CARGO_CFG_TARGET_ARCH` environment variable in the hopes that we get the desired behavior.