### PR TITLE
examples/c: Use CMake stuff in CI

### DIFF
--- a/.github/docker/Dockerfile.ubuntu
+++ b/.github/docker/Dockerfile.ubuntu
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
       llvm-${LLVM_VERSION}-dev \
       llvm-${LLVM_VERSION}-runtime \
       libllvm${LLVM_VERSION} \
-      make pkg-config \
+      make cmake pkg-config \
       rustc cargo rustfmt \
       sudo \
       && apt-get -y clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,20 @@ jobs:
           SHORTNAME=jammy
         file: ./.github/docker/Dockerfile.ubuntu
         tags: build_container
-    - name: Build examples/c
+    - name: Build examples/c -- GNU Make
       run: |
         docker run \
           -v $(pwd):/libbpf-bootstrap \
           build_container \
           /bin/bash -c \
           'cd /libbpf-bootstrap/examples/c && make -j`nproc`'
+    - name: Build examples/c -- CMake
+      run: |
+        docker run \
+          -v $(pwd):/libbpf-bootstrap \
+          build_container \
+          /bin/bash -c \
+          'cd /libbpf-bootstrap/examples/c && cmake ./ && make'
     - name: Build examples/rust
       run: |
         docker run \

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.16)
-project(examples)
+project(examples C)
 
 # Tell cmake where to find BpfObject module
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/cmake)


### PR DESCRIPTION
As #258 showed, we also have a CMake based build infrastructure lying around for the examples. However, currently it is not used in CI and, hence, prone to breakage.
Change that fact by building using CMake as part of the build workflow.