### PR TITLE
ci: add llvm-20 and fix llvm-19

### DIFF
--- a/.github/docker/Dockerfile.ubuntu
+++ b/.github/docker/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ ARG SHORTNAME="jammy"
 ENV SHORTNAME=$SHORTNAME
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN if [ "${LLVM_VERSION}" = "19" ]; \
+RUN if [ "${LLVM_VERSION}" = "20" ]; \
     then \
         echo "\n\
 deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [11, 12, 13, 14, 15, 16, 17, 18, 19]
+        llvm: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
With LLVM 20 being a new development version, add it and fix LLVM 19 build as a side effect.