### PR TITLE
Replace `libbpf` submodule with symbolic link in `bpftool`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "libbpf"]
-	path = libbpf
-	url = https://github.com/libbpf/libbpf.git
 [submodule "bpftool"]
 	path = bpftool
 	url = https://github.com/libbpf/bpftool

--- a/libbpf
+++ b/libbpf
@@ -1,0 +1,1 @@
+bpftool/libbpf


### PR DESCRIPTION
This PR removes the `libbpf` submodule in favor of a symbolic link to the `libbpf` directory within `bpftool`. The goal is to reduce redundancy and make dependency management easier, as both projects share the same `libbpf` implementation.

#### Key Changes:

- Removed the `libbpf` submodule from the repository.
- Created a symbolic link to `bpftool`'s `libbpf` directory.
  
#### Benefits:

- **Consistency**: Both `libbpf` instances are always in sync between `bpftool` and this repository.
- **Simplified Workflow**: No need to update the `libbpf` submodule separately.
