### PR TITLE
Remove backing qdisc on cleanup

### DIFF
--- a/examples/c/tc.c
+++ b/examples/c/tc.c
@@ -78,8 +78,13 @@ int main(int argc, char **argv)
 	}
 
 cleanup:
-	if (hook_created)
+	if (hook_created) {
+		/* Explicitly ask for the backing qdisc to be destroyed. Otherwise, only the BPF filters will be removed.
+		 * See https://patchwork.kernel.org/project/netdevbpf/patch/20210428162553.719588-3-memxor@gmail.com/
+		 */
+		tc_hook.attach_point = BPF_TC_INGRESS|BPF_TC_EGRESS;
 		bpf_tc_hook_destroy(&tc_hook);
+	}
 	tc_bpf__destroy(skel);
 	return -err;
 }


### PR DESCRIPTION
Hi! I've been playing around with Go's bindings for `libbpf` (i.e. [`aquasecurity/libbpfgo`](https://github.com/aquasecurity/libbpfgo)) and found that their example of how to use BPF-based TC filters did not clean the backing `qdisc` after the cleanup.

Even though this behaviour was not causing any issues, I decided to dive into `libbpf`'s implementation and found that, indeed, a backing `qdisc` is only removed if the attach point of the hook is `BPF_TC_INGRESS|BPF_TC_EGRESS` which is usually not the case. In that way, `libbpf`'s API is 'forcing' the user to explicitly request the clearing of the `qdisc`. This behaviour is documented in the associated [patch series](https://patchwork.kernel.org/project/netdevbpf/patch/20210428162553.719588-3-memxor@gmail.com/).

Anyway, this PR simply forces the removal of the backing `qdisc` by setting `tc_hook.attach_point = BPF_TC_INGRESS|BPF_TC_EGRESS;` just before the call to `bpf_tc_hook_destroy`. Given the example is rather self-contained I suppose that makes sense? The rationale behind opening up the PR is that it took me several hours to get to the patch series and I was hoping the next person wouldn't have to do the same... Maybe this can be left as a comment in `tc.c` even if one decides not to remove the `qdisc`?

In a real-world approach I suppose one could use the return value of `bpf_tc_hook_create` to decide whether to remove the `qdisc` or not so that the backing `qdisc` is only removed if the return value is `-EEXIST`? Judging by the comment above the call to `bpf_tc_hook_create` I suppose this behaviour was known by the original author of `tc.c`, but I feel like a clarification would be great for people using these examples as scaffolding for larger projects.

Thanks a ton for all this work! It's really helped me up to this moment and I'm sure it'll continue to do so for quite a while!