### PR TITLE
Profile: command line switch for virtual machine

### DIFF
--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -43,7 +43,7 @@ struct stacktrace_event {
     ustack: [u64; MAX_STACK_DEPTH],
 }
 
-fn init_perf_monitor(freq: u64) -> Result<Vec<i32>, libbpf_rs::Error> {
+fn init_perf_monitor(freq: u64, sw_event: bool) -> Result<Vec<i32>, libbpf_rs::Error> {
     let nprocs = libbpf_rs::num_possible_cpus().unwrap();
     let pid = -1;
     let buf: Vec<u8> = vec![0; mem::size_of::<syscall::perf_event_attr>()];
@@ -52,17 +52,30 @@ fn init_perf_monitor(freq: u64) -> Result<Vec<i32>, libbpf_rs::Error> {
             buf.leak().as_mut_ptr() as *mut syscall::perf_event_attr
         )
     };
-    attr._type = syscall::PERF_TYPE_HARDWARE;
+    attr._type = if sw_event {
+        syscall::PERF_TYPE_SOFTWARE
+    } else {
+        syscall::PERF_TYPE_HARDWARE
+    };
     attr.size = mem::size_of::<syscall::perf_event_attr>() as u32;
-    attr.config = syscall::PERF_COUNT_HW_CPU_CYCLES;
+    attr.config = if sw_event {
+        syscall::PERF_COUNT_SW_CPU_CLOCK
+    } else {
+        syscall::PERF_COUNT_HW_CPU_CYCLES
+    };
     attr.sample.sample_freq = freq;
     attr.flags = 1 << 10; // freq = 1
     (0..nprocs)
         .map(|cpu| {
             let fd = syscall::perf_event_open(attr.as_ref(), pid, cpu as i32, -1, 0) as i32;
             if fd == -1 {
-                Err(libbpf_rs::Error::from(io::Error::last_os_error()))
-                    .context("failed to open perf event")
+                let mut error_context = "Failed to open perf event.";
+                let os_error = io::Error::last_os_error();
+                if !sw_event && os_error.kind() == io::ErrorKind::NotFound {
+                    error_context = "Failed to open perf event.\n\
+                                    Try running the profile example with the `--sw-event` option.";
+                }
+                Err(libbpf_rs::Error::from(os_error)).context(error_context)
             } else {
                 Ok(fd)
             }
@@ -224,6 +237,12 @@ struct Args {
     /// Increase verbosity (can be supplied multiple times).
     #[arg(short = 'v', long = "verbose", global = true, action = ArgAction::Count)]
     verbosity: u8,
+    /// Use software event for triggering stack trace capture.
+    ///
+    /// This can be useful for compatibility reasons if hardware event is not available
+    /// (which could happen in a virtual machine, for example).
+    #[arg(long = "sw-event")]
+    sw_event: bool,
 }
 
 fn main() -> Result<(), libbpf_rs::Error> {
@@ -251,7 +270,7 @@ fn main() -> Result<(), libbpf_rs::Error> {
     let open_skel = skel_builder.open(&mut open_object).unwrap();
     let skel = open_skel.load().unwrap();
 
-    let pefds = init_perf_monitor(freq)?;
+    let pefds = init_perf_monitor(freq, args.sw_event)?;
     let _links = attach_perf_event(&pefds, &skel.progs.profile);
 
     let mut builder = libbpf_rs::RingBufferBuilder::new();

--- a/examples/rust/profile/src/syscall.rs
+++ b/examples/rust/profile/src/syscall.rs
@@ -54,7 +54,9 @@ pub struct perf_event_attr {
 }
 
 pub const PERF_TYPE_HARDWARE: u32 = 0;
+pub const PERF_TYPE_SOFTWARE: u32 = 1;
 pub const PERF_COUNT_HW_CPU_CYCLES: u64 = 0;
+pub const PERF_COUNT_SW_CPU_CLOCK: u64 = 0;
 
 extern "C" {
     fn syscall(number: libc::c_long, ...) -> libc::c_long;


### PR DESCRIPTION
Fix #313 

This PR introduces a new command line argument to the profile example, allowing users to specify the platform type (`host` or `guest`, default is `host`). This ensures the correct performance monitoring attributes are used based on user's input.

Key Changes:
1. Adjust performance monitoring attributes based on the `-p` argument.
2. Provide a hint when a `perf_event_open` error occurs, recommending the `-p guest` option for virtual machines.
