### PR TITLE
deps: update blazesym submodule to v0.2.0-rc.2

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "cpp_demangle",
  "gimli",


### PR DESCRIPTION
Update the blazesym submodule to version 0.2.0-rc.2 (well, actually to 0.1.0-rc.2 of blazesym-c, but they are effectively the same).