### PR TITLE
Have Dependabot only update libbpf-rs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,7 @@ updates:
   - package-ecosystem: cargo
     versioning-strategy: auto
     directory: examples/rust/
+    allow:
+      - dependency-name: libbpf-rs
     schedule:
       interval: daily


### PR DESCRIPTION
The main reason we enabled Dependabot for the repository was to keep the `libbpf-rs` version we use in-sync with current upstream releases, but by default it manages all other dependencies as well. Configure it so that it only manages `libbpf-rs`.