### PR TITLE
deps: update blazesym submodule to v0.2.0-rc.3

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "cpp_demangle",
  "gimli",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -149,9 +149,9 @@ fn show_stack_trace(stack: &[u64], symbolizer: &symbolize::Symbolizer, pid: u32)
     };
 
     let src = if pid == 0 {
-        symbolize::Source::from(symbolize::Kernel::default())
+        symbolize::source::Source::from(symbolize::source::Kernel::default())
     } else {
-        symbolize::Source::from(symbolize::Process::new(pid.into()))
+        symbolize::source::Source::from(symbolize::source::Process::new(pid.into()))
     };
 
     let syms = match symbolizer.symbolize(&src, symbolize::Input::AbsAddr(stack)) {


### PR DESCRIPTION
Update the `blazesym` submodule to version `0.2.0-rc.3` (well, actually to `0.1.0` of `blazesym-c`, but they are effectively the same).