### PR TITLE
Revert "Don't specify minimum Rust version for examples"

### DIFF
--- a/examples/rust/profile/Cargo.toml
+++ b/examples/rust/profile/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kuifeng Lee <kuifeng@fb.com>"]
 license = "GPL-2.0 OR BSD-3-Clause"
 edition = "2021"
+rust-version = "1.71"
 
 [dependencies]
 blazesym = { path = "../../../blazesym", features = ["tracing"] }

--- a/examples/rust/tracecon/Cargo.toml
+++ b/examples/rust/tracecon/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Magnus Kulke <mkulke@gmail.com>"]
 edition = "2021"
 license = "GPL-2.0 OR BSD-3-Clause"
+rust-version = "1.71"
 
 [dependencies]
 anyhow = "1.0"

--- a/examples/rust/xdp/Cargo.toml
+++ b/examples/rust/xdp/Cargo.toml
@@ -3,6 +3,7 @@ name = "xdp"
 version = "0.1.0"
 authors = ["Hengqi Chen <chenhengqi@outlook.com>"]
 edition = "2021"
+rust-version = "1.71"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Reverts libbpf/libbpf-bootstrap#343

Seems to be passing on one CI run [[0]](https://github.com/libbpf/libbpf-bootstrap/actions/runs/15398515693/job/43325201108), not so on another [[1]](https://github.com/libbpf/libbpf-bootstrap/actions/runs/15398683804/job/43325745192?pr=342).