### PR TITLE
deps: update `blazesym` submodule to v0.2.0

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 dependencies = [
  "cpp_demangle",
  "gimli",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
  "indexmap",

--- a/examples/rust/profile/src/main.rs
+++ b/examples/rust/profile/src/main.rs
@@ -93,9 +93,9 @@ fn attach_perf_event(
 fn print_frame(
     name: &str,
     addr_info: Option<(blazesym::Addr, blazesym::Addr, usize)>,
-    code_info: &Option<symbolize::CodeInfo>,
+    code_info: Option<&symbolize::CodeInfo>,
 ) {
-    let code_info = code_info.as_ref().map(|code_info| {
+    let code_info = code_info.map(|code_info| {
         let path = code_info.to_path();
         let path = path.display();
 
@@ -169,9 +169,9 @@ fn show_stack_trace(stack: &[u64], symbolizer: &symbolize::Symbolizer, pid: u32)
                 inlined,
                 ..
             }) => {
-                print_frame(&name, Some((input_addr, addr, offset)), &code_info);
+                print_frame(&name, Some((input_addr, addr, offset)), code_info.as_deref());
                 for frame in inlined.iter() {
-                    print_frame(&frame.name, None, &frame.code_info);
+                    print_frame(&frame.name, None, frame.code_info.as_ref());
                 }
             }
             symbolize::Symbolized::Unknown(..) => {


### PR DESCRIPTION
Update the `blazesym` submodule to version `0.2.0` (well, actually to `0.1.5` of `blazesym-c`, but they are almost the same).