### PR TITLE
examples/c: Fix ringbuf leaks in  C libbpf examples

### DIFF
--- a/examples/c/bootstrap.bpf.c
+++ b/examples/c/bootstrap.bpf.c
@@ -45,6 +45,9 @@ int handle_exec(struct trace_event_raw_sched_process_exec *ctx)
 	if (!e)
 		return 0;
 
+	/* zero out buffer to avoid leaking prior record bytes */
+	__builtin_memset(e, 0, sizeof(*e));
+
 	/* fill out the sample with data */
 	task = (struct task_struct *)bpf_get_current_task();
 
@@ -94,6 +97,9 @@ int handle_exit(struct trace_event_raw_sched_process_template *ctx)
 	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
 	if (!e)
 		return 0;
+
+	/* zero out buffer to avoid leaking prior record bytes */
+	__builtin_memset(e, 0, sizeof(*e));
 
 	/* fill out the sample with data */
 	task = (struct task_struct *)bpf_get_current_task();

--- a/examples/c/profile.bpf.c
+++ b/examples/c/profile.bpf.c
@@ -14,6 +14,13 @@ struct {
 	__uint(max_entries, 256 * 1024);
 } events SEC(".maps");
 
+/* zero out buffer (manual byte loop, struct is too big for inline memset) */
+static __noinline void zero_buf(void *p, __u64 sz)
+{
+	for (__u64 i = 0; i < sz; i++)
+		*(volatile char *)((char *)p + i) = 0;
+}
+
 SEC("perf_event")
 int profile(void *ctx)
 {
@@ -25,6 +32,10 @@ int profile(void *ctx)
 	event = bpf_ringbuf_reserve(&events, sizeof(*event), 0);
 	if (!event)
 		return 1;
+
+	/* zero out buffer to avoid leaking prior record bytes (kstack/ustack
+	 * tail past *_sz is only partially written by bpf_get_stack) */
+	zero_buf(event, sizeof(*event));
 
 	event->pid = pid;
 	event->cpu_id = cpu_id;

--- a/examples/c/sockfilter.bpf.c
+++ b/examples/c/sockfilter.bpf.c
@@ -49,6 +49,10 @@ int socket_handler(struct __sk_buff *skb)
 	if (!e)
 		return 0;
 
+	/* zero out buffer to avoid leaking prior record bytes (the GRE
+	 * branch below skips writing src_addr/dst_addr) */
+	__builtin_memset(e, 0, sizeof(*e));
+
 	bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, protocol), &e->ip_proto, 1);
 
 	if (e->ip_proto != IPPROTO_GRE) {


### PR DESCRIPTION
Three libbpf-bootstrap examples (`bootstrap`, `profile`, and `sockfilter`) call `bpf_ringbuf_reserve()` to obtain an event buffer, populate a subset of the event's fields, and emit the full `sizeof(*event)` bytes via `bpf_ringbuf_submit()`. `bpf_ringbuf_reserve()` does not zero-initialize the returned memory. Any bytes the source-level path leaves unwritten retain whatever the slot held previously. This can leak previously emitted record content back to userspace on subsequent events.

The `bootstrap` leak was tested on Linux 6.8. `struct event` is written by two asymmetric handlers (`handle_exec` and `handle_exit`), each of which leaves the other handler's fields untouched, plus a 4-byte padding hole that neither handler writes. Across 3,000 captured events, exit events leaked prior exec records' `filename` paths and exec events leaked prior exit records' `exit_code`/`duration_ns` bytes.

 `__builtin_memset(event, 0, sizeof(*event))` does not work for `profile` since the struct (2080 bytes) exceeds LLVM's inline-store budget. LLVM lowers this memset to a libcall, which BPF programs do not support. BPF cannot link against libc and the BPF backend has no `memset` symbol to resolve, which causes compilation to fail. The added `zero_buf()` helper avoids this by writing the byte loop explicitly in a `__noinline` subprogram, so it lands as a single BPF-to-BPF call, and by using `volatile` writes so LLVM's loop-idiom recognition does not re-lower it back into `__builtin_memset`.